### PR TITLE
Handle multiple labels in 1001 Tracklists userscript

### DIFF
--- a/1001_Tracklists/script.user.js
+++ b/1001_Tracklists/script.user.js
@@ -59,7 +59,10 @@ function thousandoneTl() {
             if( $(this).attr("data-trno") != "" ) {
                 var track = "",
                     song = $("div .trackValue",this).text().trim(),
-                    label = $("div[itemprop='tracks'] .trackLabel",this).text().trim().toLowerCase(),
+                    label = $("div[itemprop='tracks'] .trackLabel",this)
+                                .map(function(){ return $(this).text().trim(); })
+                                .get()
+                                .join(" / "),
                     dur = $("div[data-mode='hours']",this).text().trim();
 
                 if( dur != "" ) track = "["+dur+"] ";


### PR DESCRIPTION
## Summary
- Correct label parsing to join multiple labels with " / " in 1001 Tracklists userscript.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a9aa2b548320aab92019a8dc73d4