### PR TITLE
Avoid consecutive duplicate tracks on TrackId

### DIFF
--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-TrackId.net_98
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-TrackId.net_99
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-TrackId.net_65
 // @include      http*trackid.net*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=trackid.net
@@ -688,7 +688,8 @@ waitForKeyElements(".mdb-tid-table:not('.tlEditor-processed')", function( jNode 
         if( tlApi ) {
             var tl_arr = make_tlArr( tlApi ),
                 tl_arr_fixedCues = tidMarkFalseCues( addCueDiffs( tl_arr ) ),
-                tl_fixedCues = arr_toTlText( tl_arr_fixedCues );
+                tl_arr_noDupes = removeAdjacentDuplicateTracks( tl_arr_fixedCues ),
+                tl_fixedCues = arr_toTlText( tl_arr_noDupes );
 
             log( "tl_fixedCues:\n" + tl_fixedCues );
 

--- a/includes/global.js
+++ b/includes/global.js
@@ -904,6 +904,30 @@ function tidMarkFalseCues(tl_arr, minGap = 3) {
 }
 
 /*
+ * removeAdjacentDuplicateTracks
+ * Remove tracks that directly repeat the previous track
+ */
+function removeAdjacentDuplicateTracks(tl_arr) {
+  let previousKey = null;
+  const result = [];
+
+  tl_arr.forEach(item => {
+    if (item.type === "track") {
+      const key = `${item.trackText}||${item.label || ""}`;
+      if (key !== previousKey) {
+        result.push(item);
+        previousKey = key;
+      }
+    } else {
+      previousKey = null;
+      result.push(item);
+    }
+  });
+
+  return result;
+}
+
+/*
  * arr_toTlText
  */
 function arr_toTlText( tl_arr ) {


### PR DESCRIPTION
## Summary
- add helper to drop directly repeated tracks when parsing TrackId.net tracklists
- apply duplicate removal in TrackId.net script and bump global.js include version

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bb76aa748320bc087df3663f7269