### PR TITLE
feat: expand artist matching in Tracklist Merger

### DIFF
--- a/includes/global.js
+++ b/includes/global.js
@@ -753,7 +753,7 @@ function makeTracklistFromArr( tlArr, from="", cues="" ) {
 function removePointlessVersions( t ) {
     return t
         .replace( / \((Vocal|Main|Radio|Album|Single)\s?(Version|Edit|Mix)?\)/gmi, "" )
-        .replace( /\s*\(([^)]*\b(?:mix|remix|edit|version|dub)\b[^)]*)\)/gmi, "" );
+        .replace( /\s*\(([^)]*\b(?:mix|remix|edit|version|dub|part)\b[^)]*)\)/gmi, "" );
 }
 
 /*  


### PR DESCRIPTION
## Summary
- remove labels during normalization
- generate artist combination variants for matching
- strip `(Part X)` phrases when normalizing versions

## Testing
- `node --check Tracklist_Merger/script.user.js`
- `node --check includes/global.js`
- `node - <<'NODE' ...` (verify getTrackMatchNorms output)


------
https://chatgpt.com/codex/tasks/task_e_68a6f203338c8320a33adc7c3a6de4ed