### PR TITLE
feat(tracklist-merger): match artist commas and extended

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -112,7 +112,9 @@ function normalizeTrackTitlesForMatching( text ) {
     if (parts.length > 1) {
         var artists = parts.shift();
         var title = parts.join(" - ");
-        artists = artists.replace(/\s*(?:Ft|Feat\.?|Featuring|\baka\b)\s+/gi, " & ");
+        artists = artists
+            .replace(/\s*(?:Ft|Feat\.?|Featuring|\baka\b)\s+/gi, " & ")
+            .replace(/\s*,\s*/g, " & ");
         var artistsArr = artists.split(/\s*(?:&|\band\b)\s*/i);
         if (artistsArr.length > 1) {
             artistsArr = artistsArr.map(a => a.trim()).sort((a, b) => a.localeCompare(b));
@@ -140,7 +142,9 @@ function getTrackMatchNorms( text ) {
         return [ normalizeTrackTitlesForMatching( text ) ];
     }
 
-    var artists = parts.shift().replace(/\s*(?:Ft|Feat\.?|Featuring|\baka\b)\s+/gi, " & ");
+    var artists = parts.shift()
+        .replace(/\s*(?:Ft|Feat\.?|Featuring|\baka\b)\s+/gi, " & ")
+        .replace(/\s*,\s*/g, " & ");
     var title = parts.join(" - ");
     var artistsArr = artists.split(/\s*(?:&|\band\b|\baka\b)\s*/i).map(a => a.trim()).filter(Boolean);
     artistsArr = [...new Set(artistsArr)];

--- a/includes/global.js
+++ b/includes/global.js
@@ -753,7 +753,7 @@ function makeTracklistFromArr( tlArr, from="", cues="" ) {
 function removePointlessVersions( t ) {
     return t
         .replace( / \((Vocal|Main|Radio|Album|Single)\s?(Version|Edit|Mix)?\)/gmi, "" )
-        .replace( /\s*\(([^)]*\b(?:mix|remix|edit|version|dub|part)\b[^)]*)\)/gmi, "" );
+        .replace( /\s*\(([^)]*\b(?:mix|remix|edit|version|dub|part|extended)\b[^)]*)\)/gmi, "" );
 }
 
 /*  

--- a/includes/youtube_funcs.js
+++ b/includes/youtube_funcs.js
@@ -12,7 +12,7 @@ function escapeRegExp(string) {
 // removeVersionWords
 function removeVersionWords( t ) {
     return t
-            .replace( / (Original( Mix)?( Remastered)?|remix(?: \d+)?|rmx|rx|mixx?|version|vocal|Encore|Edit(?:!ion)?|Re-?Edit|Re-?work|Re-?Touch|Re-?model|Re-?Rub|Re-?vision|Re-?construction|Re-?make|Bemix|ori?gi?nal|orig|remaster(ed)?|process(?:ed)?|reshaped?|reconstruct.{,3}|(?:Re)?definition(?:!\sRec)|Perspective|interpretation|Translation|redo|re-?beef|re-?ruff|re-?prise|ReTop|Instr(?:\.)?umental(?: Version)?|acc?app?(?:ella)?|Dub Mix|Dub[a-z]{,6}mental|M[au]sh(?: )?Up)/gmi, " " )
+            .replace( / (Original( Mix)?( Remastered)?|remix(?: \d+)?|rmx|rx|mixx?|version|vocal|Encore|Extended|Edit(?:!ion)?|Re-?Edit|Re-?work|Re-?Touch|Re-?model|Re-?Rub|Re-?vision|Re-?construction|Re-?make|Bemix|ori?gi?nal|orig|remaster(ed)?|process(?:ed)?|reshaped?|reconstruct.{,3}|(?:Re)?definition(?:!\sRec)|Perspective|interpretation|Translation|redo|re-?beef|re-?ruff|re-?prise|ReTop|Instr(?:\.)?umental(?: Version)?|acc?app?(?:ella)?|Dub Mix|Dub[a-z]{,6}mental|M[au]sh(?: )?Up)/gmi, " " )
             .trim();
 }
 


### PR DESCRIPTION
## Summary
- treat commas as collaborator separators in track normalization
- strip Extended versions when normalizing titles

## Testing
- `node - <<'NODE'
const fs = require('fs');
function extract(file, fnName){
  const content = fs.readFileSync(file,'utf8');
  const regex = new RegExp('function '+fnName+'[^]*?\n}');
  const match = content.match(regex);
  if(!match) throw new Error('not found '+fnName);
  globalThis[fnName] = eval('(' + match[0] + ')');
}
function logVar(){}
extract('includes/global.js','removePointlessVersions');
extract('includes/global.js','normalizeStreamingServiceTracks');
extract('includes/youtube_funcs.js','removeVersionWords');
extract('Tracklist_Merger/script.user.js','normalizeTrackTitlesForMatching');
extract('Tracklist_Merger/script.user.js','getTrackMatchNorms');
const cases = [
  'TH;EN, Jonas Saalbach - Around Us',
  'TH;EN & Jonas Saalbach - Around Us',
  'Einmusik, Lexer - Crush (Extended)',
  'Einmusik & Lexer - Crush'
];
for(const c of cases){
  console.log(c, '=>', normalizeTrackTitlesForMatching(c));
}
console.log('\ngetTrackMatchNorms result for collab with comma:', getTrackMatchNorms('TH;EN, Jonas Saalbach - Around Us'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a72107d3448320bbc005edcbdec83c