### PR TITLE
Handle label/version when matching artist combinations

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2025.08.21.5
+// @version      2025.08.21.7
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -136,18 +136,15 @@ function normalizeTrackTitlesForMatching( text ) {
  * Return normalized variants for all artist combinations
  */
 function getTrackMatchNorms( text ) {
-    text = text.trim().replace(/\s*\[[^\]]+\]\s*/g, ' ');
+    text = normalizeTrackTitlesForMatching( text );
 
     var parts = text.split(" - ");
     if (parts.length < 2) {
-        return [ normalizeTrackTitlesForMatching( text ) ];
+        return [ text ];
     }
 
-    var artists = parts.shift()
-        .replace(/\s*(?:Ft|Feat\.?|Featuring|\baka\b)\s+/gi, " & ")
-        .replace(/\s*,\s*/g, " & ");
+    var artistsArr = parts.shift().split(/\s*&\s*/).map(a => a.trim()).filter(Boolean);
     var title = parts.join(" - ");
-    var artistsArr = artists.split(/\s*(?:&|\band\b|\baka\b)\s*/i).map(a => a.trim()).filter(Boolean);
     artistsArr = [...new Set(artistsArr)];
 
     var combos = [];
@@ -155,7 +152,7 @@ function getTrackMatchNorms( text ) {
     function combine(start, combo) {
         if (combo.length) {
             var artistStr = combo.slice().sort((a,b) => a.localeCompare(b)).join(" & ");
-            combos.push( normalizeTrackTitlesForMatching( artistStr + " - " + title ) );
+            combos.push( artistStr + " - " + title );
         }
         for (var i = start; i < artistsArr.length; i++) {
             combo.push( artistsArr[i] );
@@ -167,7 +164,7 @@ function getTrackMatchNorms( text ) {
     combine(0, []);
 
     if (!combos.length) {
-        combos.push( normalizeTrackTitlesForMatching( text ) );
+        combos.push( text );
     }
 
     return [...new Set(combos)];


### PR DESCRIPTION
## Summary
- normalize tracks before generating artist combinations to ignore labels and versions
- bump Tracklist Merger userscript version

## Testing
- `node - <<'NODE'
function removePointlessVersions(t){ return t.replace(/ \((Vocal|Main|Radio|Album|Single)\s?(Version|Edit|Mix)?\)/gmi,"" ).replace(/\s*\(([^)]*\b(?:mix|remix|edit|version|dub|part|extended)\b[^)]*)\)/gmi,""); }
function removeVersionWords(t){ return t.replace( / (Original( Mix)?( Remastered)?|remix(?: \d+)?|rmx|rx|mixx?|version|vocal|Encore|Extended|Edit(?:!ion)?|Re-?Edit|Re-?work|Re-?Touch|Re-?model|Re-?Rub|Re-?vision|Re-?construction|Re-?make|Bemix|ori?gi?nal|orig|remaster(ed)?|process(?:ed)?|reshaped?|reconstruct.{,3}|(?:Re)?definition(?:!\sRec)|Perspective|interpretation|Translation|redo|re-?beef|re-?ruff|re-?prise|ReTop|Instr(?:\.)?umental(?: Version)?|acc?app?(?:ella)?|Dub Mix|Dub[a-z]{,6}mental|M[au]sh(?: )?Up)/gmi, " " ).trim(); }
function normalizeStreamingServiceTracks(text){ var textOut = text.replace(/\[/g,"(").replace(/\]/g,")"); textOut = textOut.replace(" (Mixed)",""); textOut = textOut.replace(/ID\d+( \(from.+\))?/g,"ID").replace("ID / ID","ID").replace(/\s+/g," "); return textOut; }
function logVar(){}
function normalizeTrackTitlesForMatching( text ) { text = text.trim(); text = text.replace(/\s*\[[^\]]+\]\s*/g, ' '); text = normalizeStreamingServiceTracks( text ); text = removePointlessVersions( text ); text = removeVersionWords( text ).replace( / \((.+) \)/, " ($1)" ); text = text.replace( /^(.+) (?:Ft|Feat\.|Featuring?) .+ - (.+)$/, "$1 - $2" ); var parts = text.split(" - "); if (parts.length > 1) { var artists = parts.shift(); var title = parts.join(" - "); artists = artists .replace(/\s*(?:Ft|Feat\.?|Featuring|\baka\b)\s+/gi, " & ") .replace(/\s*,\s*/g, " & "); var artistsArr = artists.split(/\s*(?:&|\band\b)\s*/i); if (artistsArr.length > 1) { artistsArr = artistsArr.map(a => a.trim()).sort((a, b) => a.localeCompare(b)); artists = artistsArr.join(" & "); } text = artists + " - " + title; } text = text.toLowerCase().replace(/\s{2,}/g, ' ').trim(); return text; }
function getTrackMatchNorms( text ) { text = normalizeTrackTitlesForMatching( text ); var parts = text.split(" - "); if (parts.length < 2) { return [ text ]; } var artistsArr = parts.shift().split(/\s*&\s*/).map(a => a.trim()).filter(Boolean); var title = parts.join(" - "); artistsArr = [...new Set(artistsArr)]; var combos = []; function combine(start, combo) { if (combo.length) { var artistStr = combo.slice().sort((a,b) => a.localeCompare(b)).join(" & "); combos.push( artistStr + " - " + title ); } for (var i = start; i < artistsArr.length; i++) { combo.push( artistsArr[i] ); combine( i + 1, combo ); combo.pop(); } } combine(0, []); if (!combos.length) { combos.push( text ); } return [...new Set(combos)]; }
console.log(getTrackMatchNorms('Bar Shaked, Mai Yani - Take It All Out (Avoure Remix)'));
console.log(getTrackMatchNorms('Bar Shaked - Take It All Out [Magnetic Magazine]'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a98b58c4c08320956102950aabe7c0