### PR TITLE
Tracklist Merger: refine diff highlighting

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -432,14 +432,14 @@ function mergeTracklists(original_arr, candidate_arr) {
       return lead + (core ? '<span class="' + cls + '">' + escapeHTML(core) + '</span>' : '') + trail;
     }
     function charDiffGreen(orig, mod) {
-      return Diff.diffChars(orig, mod).map(function(p) {
+      return Diff.diffWords(orig, mod).map(function(p) {
         if (p.added)   return wrapSpan(p.value, 'diff-added');
         if (p.removed) return '';
         return escapeHTML(p.value);
       }).join('');
     }
     function charDiffRed(orig, mod) {
-      return Diff.diffChars(orig, mod).map(function(p) {
+      return Diff.diffWords(orig, mod).map(function(p) {
         if (p.added)   return wrapSpan(p.value, 'diff-removed');
         if (p.removed) return '';
         return escapeHTML(p.value);


### PR DESCRIPTION
## Summary
- Use word-based diffing to highlight only changed text segments instead of entire track lines

## Testing
- `node --check script.user.js`

------
https://chatgpt.com/codex/tasks/task_e_68a98e26e0848320a3aea323958e665c