### PR TITLE
fix: ensure minimum width for empty merger columns

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -154,7 +154,23 @@ function adjust_columnWidths() {
         return;
     }
 
-    var widths = maxLens.map(function(len){ return len / total * 100; });
+    var MIN_WIDTH = 15, // percentage
+        emptyCount = 0,
+        nonEmptyTotal = 0;
+
+    maxLens.forEach(function(len){
+        if( len === 0 ) {
+            emptyCount++;
+        } else {
+            nonEmptyTotal += len;
+        }
+    });
+
+    var remaining = 100 - MIN_WIDTH * emptyCount;
+
+    var widths = maxLens.map(function(len){
+        return len === 0 ? MIN_WIDTH : remaining * len / nonEmptyTotal;
+    });
 
     tables.forEach(function($table){
         var $colgroup = $table.children('colgroup');


### PR DESCRIPTION
## Summary
- maintain 15% minimum width for empty columns in Tracklist Merger tables

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a83b70408320bde6b494a9190686