### PR TITLE
feat(tracklist-merger): add copy button to diff

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -46,6 +46,7 @@ const similarityThreshold = 0.8;
 function clear_textareas() {
     $("#tracklistMerger-wrapper textarea").val("");
     $("#tracklistMerger-wrapper #diffContainer td").remove();
+    $("#diff-copy-row").hide();
     adjust_columnWidths();
 }
 
@@ -678,6 +679,7 @@ function run_diff() {
             adjust_preHeights( pre );
         }
         adjust_columnWidths();
+        $("#diff-copy-row").show();
     }
 }
 
@@ -823,6 +825,23 @@ function run_merge( showDebug=false ) {
  */
 if( domain == "mixesdb.com" ) {
     $(document).ready(function () {
+
+        // add copy button for diff merged column
+        $('<tr id="diff-copy-row" class="buttons">'
+            + '<td></td>'
+            + '<td style="text-align:center;"><button id="copyDiff">Copy</button></td>'
+            + '<td></td>'
+            + '</tr>').insertAfter('#diffContainer').hide();
+
+        $('#copyDiff').on('click', function(){
+            var text = $('#diffContainer td').eq(1).find('pre').text();
+            if (!text) return;
+            navigator.clipboard.writeText(text).catch(function(){
+                var $temp = $('<textarea>').val(text).appendTo('body').select();
+                document.execCommand('copy');
+                $temp.remove();
+            });
+        });
 
         $("#clear").click(function(){
             clear_textareas();


### PR DESCRIPTION
## Summary
- Add Copy button below Diff section's merged column to copy its contents
- Auto-hide copy button when clearing inputs and reveal after diff generation
- Ensure clipboard write fallback for unsupported browsers

## Testing
- `node --check Tracklist_Merger/script.user.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ab0ba5f08320bab981f70f227eb1