### PR TITLE
Tracklist Merger: restore 2025.08.20.6 diff logic

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -11,7 +11,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Tracklist_Merger_Beta_9
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
-// @require      https://cdn.jsdelivr.net/npm/diff@5.2.0/dist/diff.min.js
+// @require      https://cdn.jsdelivr.net/npm/diff@5.1.0/dist/diff.min.js
 // @match        https://www.mixesdb.com/w/MixesDB:Tests/Tracklist_Merger*
 // @include      http*trackid.net/audiostreams/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
@@ -28,7 +28,6 @@
 
 const tid_minGap = 3;
 const similarityThreshold = 0.8;
-const diffSimilarityThreshold = 0.5;
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -556,27 +555,7 @@ function mergeTracklists(original_arr, candidate_arr) {
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-function calcSimilarity(a, b) {
-  var m = a.length, n = b.length;
-  var dp = Array(m + 1);
-  for (var i = 0; i <= m; i++) {
-    dp[i] = Array(n + 1).fill(0);
-  }
-  for (var i = 1; i <= m; i++) {
-    for (var j = 1; j <= n; j++) {
-      var cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      dp[i][j] = Math.min(
-        dp[i - 1][j] + 1,
-        dp[i][j - 1] + 1,
-        dp[i - 1][j - 1] + cost
-      );
-    }
-  }
-  var maxLen = Math.max(m, n);
-  return maxLen === 0 ? 1 : (maxLen - dp[m][n]) / maxLen;
-}
-
-(function($) {
+ (function($) {
     function escapeHTML(s) { return $('<div>').text(s).html(); }
     function wrapSpan(val, cls) {
       var lead = val.match(/^\s*/)[0];
@@ -599,19 +578,9 @@ function calcSimilarity(a, b) {
       }).join('');
     }
     $.fn.showTracklistDiffs = function(opts) {
-
       var text1 = opts.text1 || '';
       var text2 = opts.text2 || '';
       var text3 = opts.text3 || '';
-
-      // Ensure each column string ends with a newline so that the
-      // corresponding <pre> elements have matching heights. Without this the
-      // Candidate column could appear one row shorter when its input lacked a
-      // trailing line break.
-      if (text1.slice(-1) !== '\n') { text1 += '\n'; }
-      if (text2.slice(-1) !== '\n') { text2 += '\n'; }
-      if (text3.slice(-1) !== '\n') { text3 += '\n'; }
-
       var lines1 = text1.split('\n');
       var lines2 = text2.split('\n');
       var lines3 = text3.split('\n');
@@ -649,35 +618,22 @@ function calcSimilarity(a, b) {
           // strip trailing label for matching
           var coreNoLabel = core.replace(/\s*\[[^\]]+\]\s*$/, '');
           var normCore = normalizeTrackTitlesForMatching(coreNoLabel);
-          var bestCore = '', bestScore = 0;
+          var origCore = '';
           for (var j = 0; j < lines2.length; j++) {
             var cand = lines2[j].replace(/^#?\s*\[.*?\]\s*/, '').trim();
             var candNoLabel = cand.replace(/\s*\[[^\]]+\]\s*$/, '');
-            var score = calcSimilarity(normalizeTrackTitlesForMatching(candNoLabel), normCore);
-            if (score > bestScore) {
-              bestScore = score;
-              bestCore = cand;
+            if ($.isTextSimilar(normalizeTrackTitlesForMatching(candNoLabel), normCore)) {
+              origCore = cand;
+              break;
             }
           }
-          var origCore = bestCore;
-          if (origCore && origCore.trim().toLowerCase() === core.trim().toLowerCase()) {
+          if (origCore.trim().toLowerCase() === core.trim().toLowerCase()) {
             return escapeHTML(line);
           }
           return escapeHTML(prefix) + charDiffRed(origCore, core);
         }).join('\n');
 
         $row.append($('<td>').append($('<pre>').html(html3)));
-
-        // Ensure each <pre> ends with a newline so that height calculations
-        // include the final line. Without this, some browsers may measure the
-        // scrollHeight one line too short, causing the Candidate column to crop
-        // its last row.
-        $row.find('pre').each(function() {
-          var $pre = $(this);
-          if (!$pre.text().endsWith('\n')) {
-            $pre.append('\n');
-          }
-        });
 
         $container.replaceWith($row);
       });
@@ -694,14 +650,7 @@ function run_diff() {
         text3 = $("#tl_candidate").val();
     if( text1 && text2 && text3 ) {
         $('#diffContainer').showTracklistDiffs({ text1, text2, text3 });
-        var pre = $('#diffContainer pre').first();
-        if( pre.length ) {
-            adjust_preHeights( pre );
-        }
-    } else {
-        $("#diffContainer td").remove();
     }
-    adjust_columnWidths();
 }
 
 


### PR DESCRIPTION
## Summary
- Revert Tracklist Merger diff behavior to 2025.08.20.6 implementation
- Switch back to diff.js 5.1.0 and drop unused diff similarity threshold
- Simplify run_diff and showTracklistDiffs to earlier, stable logic

## Testing
- `node --check Tracklist_Merger/script.user.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9e721da0c832087d1aac114c662be