### PR TITLE
Add manual column resizing to Tracklist Merger table

### DIFF
--- a/Tracklist_Merger/script.css
+++ b/Tracklist_Merger/script.css
@@ -1,6 +1,16 @@
 #tracklistMerger-wrapper {
     margin-left: -5px;
-    
+    position: relative;
+
+    & .column-divider {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 5px;
+        cursor: col-resize;
+        background: #ddd;
+    }
+
     & tr {
         margin-bottom: 10px;
         


### PR DESCRIPTION
## Summary
- Allow Tracklist Merger columns to be manually resized via drag handles
- Style column dividers for resizing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa00c28eec832097cdae1f71f65ffc