### PR TITLE
Refine candidate diff highlighting

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -32,7 +32,6 @@ loadRawCss( githubPath_raw + scriptName + "/script.css?v-" + cacheVersion );
 
 const tid_minGap = 3;
 const similarityThreshold = 0.8;
-const diffSimilarityThreshold = 0.5;
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -671,10 +670,19 @@ function calcSimilarity(a, b) {
       }).join('');
     }
     function charDiffRed(orig, mod) {
-      return Diff.diffWords(orig, mod, { ignoreCase: true }).map(function(p) {
-        if (p.added)   return wrapSpan(p.value, 'diff-removed');
-        if (p.removed) return '';
-        return escapeHTML(p.value);
+      var origSet = new Set(
+        orig
+          .toLowerCase()
+          .split(/\s+/)
+          .map(function(w){ return w.replace(/[^\w']+/g, ''); })
+          .filter(Boolean)
+      );
+      return mod.split(/(\s+)/).map(function(tok){
+        var stripped = tok.toLowerCase().replace(/[^\w']+/g, '');
+        if (!stripped || origSet.has(stripped)) {
+          return escapeHTML(tok);
+        }
+        return wrapSpan(tok, 'diff-removed');
       }).join('');
     }
     $.fn.showTracklistDiffs = function(opts) {


### PR DESCRIPTION
## Summary
- remove unused diff threshold
- highlight only words missing from merged tracklist in candidate diff

## Testing
- `node --check Tracklist_Merger/script.user.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa08604d3883208898c63ccc0b537d