### PR TITLE
Tracklist Merger: show identical tracklist message

### DIFF
--- a/Tracklist_Merger/script.css
+++ b/Tracklist_Merger/script.css
@@ -33,4 +33,8 @@
             }
         }
     }
+
+    & #diffContainer td.identical-msg {
+        text-align: center;
+    }
 }

--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2025.08.23.17
+// @version      2025.08.23.18
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -26,7 +26,7 @@
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 2,
+var cacheVersion = 3,
     scriptName = "Tracklist_Merger";
 loadRawCss( githubPath_raw + scriptName + "/script.css?v-" + cacheVersion );
 
@@ -780,10 +780,14 @@ function run_diff() {
         text2 = $("#merge_result_tle").val(),
         text3 = $("#tl_candidate").val();
     if( text1 && text2 && text3 ) {
-        $('#diffContainer').showTracklistDiffs({ text1, text2, text3 });
-        var pre = $('#diffContainer pre').first();
-        if( pre.length ) {
-            adjust_preHeights( pre );
+        if( text1 === text2 ) {
+            $("#diffContainer").html('<td colspan="3" class="identical-msg">The merged tracklist is identical to the original.</td>');
+        } else {
+            $('#diffContainer').showTracklistDiffs({ text1, text2, text3 });
+            var pre = $('#diffContainer pre').first();
+            if( pre.length ) {
+                adjust_preHeights( pre );
+            }
         }
     } else {
         $("#diffContainer td").remove();


### PR DESCRIPTION
## Summary
- Display a centered notice when the merged tracklist matches the original instead of showing diffs
- Style the identical-tracklist notice and bump version/cache to refresh assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa09a938fc8320b16368d8d4b8ef92