### PR TITLE
Highlight unmatched candidate tracks

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -790,7 +790,7 @@ function calcSimilarity(a, b) {
           var origCore = bestIdx >= 0 ? extractPrefix(lines2[bestIdx]).core : '';
           var origCoreTrim = origCore.trim();
           if (!origCore || bestScore < similarityThreshold) {
-            return escapeHTML(prefix) + charDiffRed('', core);
+            return wrapSpan(prefix + core, 'diff-removed');
           }
           // if labels differ entirely, highlight whole label
           var coreLabel = core.match(/(\s*\[[^\]]+\]\s*)$/);


### PR DESCRIPTION
## Summary
- Improve candidate diff rendering: highlight entire track row when no corresponding merge track exists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa38ec97388320b89013931b085fe4