### PR TITLE
Highlight unmatched candidate tracks

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -31,7 +31,8 @@ var cacheVersion = 4,
 loadRawCss( githubPath_raw + scriptName + "/script.css?v-" + cacheVersion );
 
 const tid_minGap = 3;
-const similarityThreshold = 0.8;
+// Allow looser matching so minor title differences are still compared
+const similarityThreshold = 0.6;
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -790,7 +791,7 @@ function calcSimilarity(a, b) {
           var origCore = bestIdx >= 0 ? extractPrefix(lines2[bestIdx]).core : '';
           var origCoreTrim = origCore.trim();
           if (!origCore || bestScore < similarityThreshold) {
-            return escapeHTML(prefix) + charDiffRed('', core);
+            return wrapSpan(prefix + core, 'diff-removed');
           }
           // if labels differ entirely, highlight whole label
           var coreLabel = core.match(/(\s*\[[^\]]+\]\s*)$/);


### PR DESCRIPTION
## Summary
- Improve candidate diff rendering: highlight entire track row when no corresponding merge track exists
- Loosen title similarity threshold so minor differences highlight per-character instead of whole line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa38ec97388320b89013931b085fe4