### PR TITLE
fix: expand version word detection

### DIFF
--- a/includes/youtube_funcs.js
+++ b/includes/youtube_funcs.js
@@ -12,7 +12,7 @@ function escapeRegExp(string) {
 // removeVersionWords
 function removeVersionWords( t ) {
     return t
-            .replace( / (Original( Mix)?( Remastered)?|remix(?: \d+)?|rmx|rx|mixx?|version|vocal|Encore|Extended|Edit(?:!ion)?|Re-?Edit|Re-?work|Re-?Touch|Re-?model|Re-?Rub|Re-?vision|Re-?construction|Re-?make|Bemix|ori?gi?nal|orig|remaster(ed)?|process(?:ed)?|reshaped?|reconstruct.{,3}|(?:Re)?definition(?:!\sRec)|Perspective|interpretation|Translation|redo|re-?beef|re-?ruff|re-?prise|ReTop|Instr(?:\.)?umental(?: Version)?|acc?app?(?:ella)?|Dub Mix|Dub[a-z]{,6}mental|M[au]sh(?: )?Up)/gmi, " " )
+            .replace( /\b(Original( Mix)?( Remastered)?|remix(?: \d+)?|rmx|rx|\w+\smixx?|\w*mixx?|version|vocal|Encore|Extended|Edit(?:!ion)?|Re-?Edit|Re-?work|Re-?Touch|Re-?model|Re-?Rub|Re-?vision|Re-?construction|Re-?make|Bemix|ori?gi?nal|orig|remaster(ed)?|process(?:ed)?|reshaped?|reconstruct.{,3}|(?:Re)?definition(?:!\sRec)|Perspective|interpretation|Translation|redo|re-?beef|re-?ruff|re-?prise|ReTop|Instr(?:\.)?umental(?: Version)?|acc?app?(?:ella)?|Dub[a-z]{,6}mental|M[au]sh(?: )?Up)\b/gmi, " " )
             .trim();
 }
 


### PR DESCRIPTION
## Summary
- improve version word detection to match variants like `Clubmix` or `Club Mix`
- keep normalization case-insensitive by using word boundaries instead of leading spaces

## Testing
- `node -e "const fs=require('fs');const vm=require('vm');const code=fs.readFileSync('includes/youtube_funcs.js','utf8');vm.runInThisContext(code);console.log(removeVersionWords('Song Title Club Mix'));console.log(removeVersionWords('Song Title Clubmix'));console.log(removeVersionWords('Song Title CLUBMIX'));"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4b5b17388320b49350998c9f375a