### PR TITLE
Tracklist Merger: refine typo diff highlighting

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -714,7 +714,7 @@ function calcSimilarity(a, b) {
           if (p.value.toLowerCase() === next.value.toLowerCase()) {
             res += escapeHTML(p.value);
           } else {
-            res += charDiff(p.value, next.value, cls);
+            res += highlightWords(p.value, cls);
           }
           i += 2;
           continue;
@@ -725,7 +725,7 @@ function calcSimilarity(a, b) {
           if (next.value.toLowerCase() === p.value.toLowerCase()) {
             res += escapeHTML(next.value);
           } else {
-            res += charDiff(next.value, p.value, cls);
+            res += highlightWords(next.value, cls);
           }
           i += 2;
           continue;


### PR DESCRIPTION
## Summary
- Highlight only the changed word when two tracks differ by a minor typo

## Testing
- `node --check Tracklist_Merger/script.user.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68ac51eabbac8320a0d383ec6bc75365