### PR TITLE
Tracklist Merger: refine typo diff highlighting

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -31,8 +31,6 @@ var cacheVersion = 5,
 loadRawCss( githubPath_raw + scriptName + "/script.css?v-" + cacheVersion );
 
 const tid_minGap = 3;
-// Threshold for fuzzy matching when merging track titles
-const similarityThreshold = 0.8;
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -537,15 +535,21 @@ function mergeTracklists(original_arr, candidate_arr) {
                 }
             }
 
-            // 2) Fallback to fuzzy matching
+            // 2) Fallback to fuzzy matching based on best similarity
             if (!origItem) {
-                outer: for (const candNorm of candNorms) {
+                let bestScore = 0;
+                let bestItem = null;
+                for (const candNorm of candNorms) {
                     for (const entry of fuzzyList) {
-                        if ($.isTextSimilar(entry.norm, candNorm, similarityThreshold)) {
-                            origItem = entry.item;
-                            break outer;
+                        const score = calcSimilarity(entry.norm, candNorm);
+                        if (score > bestScore) {
+                            bestScore = score;
+                            bestItem = entry.item;
                         }
                     }
+                }
+                if (bestScore > 0) {
+                    origItem = bestItem;
                 }
             }
         }
@@ -714,7 +718,7 @@ function calcSimilarity(a, b) {
           if (p.value.toLowerCase() === next.value.toLowerCase()) {
             res += escapeHTML(p.value);
           } else {
-            res += charDiff(p.value, next.value, cls);
+            res += highlightWords(p.value, cls);
           }
           i += 2;
           continue;
@@ -725,7 +729,7 @@ function calcSimilarity(a, b) {
           if (next.value.toLowerCase() === p.value.toLowerCase()) {
             res += escapeHTML(next.value);
           } else {
-            res += charDiff(next.value, p.value, cls);
+            res += highlightWords(next.value, cls);
           }
           i += 2;
           continue;


### PR DESCRIPTION
## Summary
- Remove threshold-based fuzzy matching and use best-score similarity to match tracks for diffing

## Testing
- `node --check Tracklist_Merger/script.user.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68ac51eabbac8320a0d383ec6bc75365