### PR TITLE
feat: add YouTube duration file details toggle

### DIFF
--- a/YouTube/script.user.js
+++ b/YouTube/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         YouTube (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2025.08.20.2
+// @version      2025.08.20.3
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -55,8 +55,20 @@ redirectOnUrlChange( 200 );
 
 var ytId = getYoutubeIdFromUrl( url );
 
+function getDurationSec_YT() {
+    var iso = $("meta[itemprop='duration']").attr("content");
+    if( typeof iso === "undefined" ) return null;
+    var m = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+    if( !m ) return null;
+    var h = parseInt(m[1] || 0, 10),
+        min = parseInt(m[2] || 0, 10),
+        s = parseInt(m[3] || 0, 10);
+    return h*3600 + min*60 + s;
+}
+
 if( ytId ) {
-    var playerUrl = "https://youtu.be/" + ytId;
+    var playerUrl = "https://youtu.be/" + ytId,
+        dur_sec = getDurationSec_YT();
     
     waitForKeyElements( "#bottom-row", function( jNode ) {
         var titleText = $("#title h1").text(),
@@ -71,4 +83,25 @@ if( ytId ) {
         // Toolkit
         getToolkit( playerUrl, "playerUrl", "detail page", wrapper, "after", titleText, "link", 1, playerUrl );
     });
+
+    if( dur_sec ) {
+        var dur = convertHMS( dur_sec );
+
+        waitForKeyElements( "#actions-inner", function( jNode ) {
+            jNode.prepend('<button id="mdb-fileInfo" class="mdb-element mdb-toggle" data-toggleid="mdb-fileDetails" title="Click to copy file details">'+dur+'</button>');
+        });
+
+        waitForKeyElements( "#description", function( jNode ) {
+            jNode.before( getFileDetails_forToggle( dur_sec ) );
+        });
+    }
 }
+
+waitForKeyElements( ".mdb-toggle", function( jNode ) {
+    jNode.click(function(){
+        var toggleId = $(this).attr("data-toggleid");
+        $("#"+toggleId).slideToggle();
+        $(this).toggleClass("selected");
+        if( toggleId == "mdb-fileDetails" ) $("#mdb-fileDetails textarea").select().focus();
+    });
+});


### PR DESCRIPTION
## Summary
- show a duration button beside video actions
- toggle a file details textarea above the description

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aebdb8b17883208353bbd421b7cdd8