### PR TITLE
feat: add YouTube duration file details toggle

### DIFF
--- a/YouTube/script.user.js
+++ b/YouTube/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         YouTube (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2025.08.20.2
+// @version      2025.08.27.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_7
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_8
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-YouTube_12
 // @include      http*youtube.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=youtube.com
@@ -55,9 +55,36 @@ redirectOnUrlChange( 200 );
 
 var ytId = getYoutubeIdFromUrl( url );
 
+function getDurationSec_YT() {
+    var sec = window.ytInitialPlayerResponse?.videoDetails?.lengthSeconds
+              || window.ytplayer?.config?.args?.length_seconds;
+    var player = document.querySelector('.html5-video-player');
+    if( player && !player.classList.contains('ad-showing') ) {
+        var hms = $(".ytp-time-duration").text().trim();
+        if( hms && hms !== "0:00" ) {
+            var parts = hms.split(":"),
+                total = 0;
+            for( var i = 0; i < parts.length; i++ ) {
+                total = total*60 + parseInt( parts[i], 10 );
+            }
+            return total;
+        }
+    }
+    if( sec ) return parseInt( sec, 10 );
+    var iso = $("meta[itemprop='duration']").attr("content");
+    if( typeof iso === "undefined" ) return null;
+    var m = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+    if( !m ) return null;
+    var h = parseInt(m[1] || 0, 10),
+        min = parseInt(m[2] || 0, 10),
+        s = parseInt(m[3] || 0, 10);
+    return h*3600 + min*60 + s;
+}
+
 if( ytId ) {
-    var playerUrl = "https://youtu.be/" + ytId;
-    
+    var playerUrl = "https://youtu.be/" + ytId,
+        dur_sec_cache = null;
+
     waitForKeyElements( "#bottom-row", function( jNode ) {
         var titleText = $("#title h1").text(),
             wrapper = jNode;
@@ -71,4 +98,29 @@ if( ytId ) {
         // Toolkit
         getToolkit( playerUrl, "playerUrl", "detail page", wrapper, "after", titleText, "link", 1, playerUrl );
     });
+
+    waitForKeyElements( ".ytp-time-duration", function() {
+        setTimeout(function(){
+            dur_sec_cache = getDurationSec_YT();
+            if( !dur_sec_cache ) return;
+
+            waitForKeyElements( "#actions-inner", function( jNode ) {
+                var dur = convertHMS( dur_sec_cache );
+                jNode.prepend('<button id="mdb-fileInfo" class="mdb-element mdb-toggle" data-toggleid="mdb-fileDetails" title="Click to copy file details">'+dur+'</button>');
+            }, true );
+
+            waitForKeyElements( "ytd-watch-metadata #description", function( jNode ) {
+                jNode.before( getFileDetails_forToggle( dur_sec_cache ) );
+            }, true );
+        }, 1000 );
+    }, true );
 }
+
+waitForKeyElements( ".mdb-toggle", function( jNode ) {
+    jNode.click(function(){
+        var toggleId = $(this).attr("data-toggleid");
+        $("#"+toggleId).slideToggle();
+        $(this).toggleClass("selected");
+        if( toggleId == "mdb-fileDetails" ) $("#mdb-fileDetails textarea").select().focus();
+    });
+});

--- a/includes/global.js
+++ b/includes/global.js
@@ -511,7 +511,8 @@ function getFileDetails_forToggle( dur_sec, bytes="" ) {
     logVar( "dur", dur );
 
     if( dur !== null ) {
-       return '<div id="mdb-fileDetails" style="display:none"><textarea class="mdb-selectOnClick" rows="9">{|{{NormalTableFormat-Bytes}}\n! dur\n! bytes\n! kbps\n|-\n| '+dur+'\n| '+bytes+'\n| \n|}</textarea></div>';
+       var mb = bytes ? ( parseInt( bytes, 10 ) / 1048576 ).toFixed( 2 ) : "";
+       return '<div id="mdb-fileDetails" style="display:none"><textarea class="mdb-selectOnClick" rows="9">{|{{NormalTableFormat}}\n! dur\n! MB\n! kbps\n|-\n| '+dur+'\n| '+mb+'\n| \n|}</textarea></div>';
     }
 }
 


### PR DESCRIPTION
## Summary
- show a duration button beside video actions
- toggle a file details textarea above the description
- ensure duration matches the player display and file details toggle inserts the NormalTableFormat template
- avoid using ad runtime by checking for YouTube's `ad-showing` state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aebdb8b17883208353bbd421b7cdd8