### PR TITLE
refactor: centralize toggle handling

### DIFF
--- a/SoundCloud/script.funcs.js
+++ b/SoundCloud/script.funcs.js
@@ -105,16 +105,3 @@ function fixScRedirectUrl( url ) {
     return url;
 }
 
-
-// toggle click
-waitForKeyElements(".mdb-toggle", function( jNode ) {
-    jNode.click(function(){
-        var toggleId = $(this).attr("data-toggleid");
-        log( toggleId );
-
-        $("#"+toggleId).slideToggle();
-        $(this).toggleClass("selected");
-
-        if( toggleId == "mdb-fileDetails" ) $("#mdb-fileDetails textarea").click();
-    });
-});

--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2025.08.27.1
+// @version      2025.08.27.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,9 +9,9 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_31
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_32
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-SoundCloud_49
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_17
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_18
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v_2
 // @include      http*soundcloud.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=soundcloud.com

--- a/YouTube/script.user.js
+++ b/YouTube/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         YouTube (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2025.08.27.6
+// @version      2025.08.27.7
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_11
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_12
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-YouTube_12
 // @include      http*youtube.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=youtube.com
@@ -112,11 +112,3 @@ if( ytId ) {
     }, true );
 }
 
-waitForKeyElements( ".mdb-toggle", function( jNode ) {
-    jNode.click(function(){
-        var toggleId = $(this).attr("data-toggleid");
-        $("#"+toggleId).slideToggle( 400 );
-        $(this).toggleClass("selected");
-        if( toggleId == "mdb-fileDetails" ) $("#mdb-fileDetails textarea").select().focus();
-    });
-});

--- a/includes/global.js
+++ b/includes/global.js
@@ -1315,6 +1315,17 @@ function convertUTCDateToLocalDate(date) {
 /* END Timeago */
 
 
+/* Toggle click */
+waitForKeyElements(".mdb-toggle", function( jNode ) {
+    jNode.on("click", function(){
+        var toggleId = $(this).attr("data-toggleid");
+        $("#"+toggleId).slideToggle( msWaitToggle );
+        $(this).toggleClass("selected");
+        if( toggleId == "mdb-fileDetails" ) $("#mdb-fileDetails textarea").select().focus();
+    });
+});
+
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *
  * End


### PR DESCRIPTION
## Summary
- centralize `.mdb-toggle` click handling in `global.js`
- remove redundant toggle handlers from YouTube and SoundCloud scripts
- bump YouTube and SoundCloud userscript versions

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aeda00a50c8320b8a9e7d2c48e9384