### PR TITLE
fix: auto-select YouTube file details on toggle

### DIFF
--- a/YouTube/script.user.js
+++ b/YouTube/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         YouTube (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2025.08.27.7
+// @version      2025.08.27.8
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -114,8 +114,12 @@ if( ytId ) {
 
 waitForKeyElements( ".mdb-toggle", function( jNode ) {
     jNode.click(function(){
-        var toggleId = $(this).attr("data-toggleid");
-        $("#"+toggleId).slideToggle( 400 );
+        var toggleId = $(this).attr("data-toggleid"),
+            target = $("#"+toggleId);
+        target.slideToggle( 400 );
         $(this).toggleClass("selected");
+
+        var textarea = target.find("textarea");
+        if( textarea.length ) textarea.click();
     });
 });


### PR DESCRIPTION
## Summary
- ensure YouTube file details textarea is selected each time the toggle opens
- bump YouTube userscript version

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/userscripts/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aee3153bbc8320b803f4aeb99bacea