### PR TITLE
SoundCloud: fix repost hiding option and bump script version

### DIFF
--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.03.23.3
+// @version      2026.04.23.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -462,7 +462,7 @@ waitForKeyElements(".soundList__item .sound.playlist", function( jNode ) {
 
 // Hiding option: each repost player
 waitForKeyElements(".soundList__item .sc-ministats-reposts", function( jNode ) {
-    if( getHidePl == "true" ) {
+    if( getHideReposts == "true" ) {
         log( "Hidden: " + jNode.closest(".soundTitle__title") );
         jNode.closest(".soundList__item").remove();
     }


### PR DESCRIPTION
### Motivation
- Fix a bug where enabling the "Playlists" hide option also removed repost items because the repost check used the wrong flag.

### Description
- Updated `SoundCloud/script.user.js` to use `getHideReposts` instead of `getHidePl` in the repost hide handler so reposts are only hidden when `hideReposts` is enabled.
- Bumped the userscript header `@version` to `2026.04.23.1` to follow the versioning policy.

### Testing
- Ran `node --check SoundCloud/script.user.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ee5d9f7c8320bfb2e90e584b9095)