### PR TITLE
Handle new SoundCloud artwork DOM and extract background-image URLs

### DIFF
--- a/SoundCloud/script.funcs.js
+++ b/SoundCloud/script.funcs.js
@@ -20,12 +20,16 @@ function append_artwork( artwork_url ) {
     logVar( "origUrl", origUrl );
 
     if( $("#mdb-artwork-wrapper").length === 0 ) {
-        $(".listenArtworkWrapper").replaceWith('<div id="mdb-artwork-wrapper"></div>');
-        var imgWrapper = $("#mdb-artwork-wrapper");
+        if( $(".listenArtworkWrapper").length ) {
+            $(".listenArtworkWrapper").replaceWith('<div id="mdb-artwork-wrapper"></div>');
+            var imgWrapper = $("#mdb-artwork-wrapper");
 
-        imgWrapper.append('<div id="mdb-artwork-input-wrapper"><input id="mdb-artwork-input" class="selectOnClick" type="text" value="'+origUrl+'" /></div>');
+            imgWrapper.append('<div id="mdb-artwork-input-wrapper"><input id="mdb-artwork-input" class="selectOnClick" type="text" value="'+origUrl+'" /></div>');
+            imgWrapper.prepend('<a class="mdb-artwork-img" href="'+origUrl+'" target="_blank"><img id="mdb-artwork-img" src="'+origUrl+'" /></a>');
 
-        imgWrapper.prepend('<a class="mdb-artwork-img" href="'+origUrl+'" target="_blank"><img id="mdb-artwork-img" src="'+origUrl+'" /></a>');
+        } else if( $(".listenInfo .listenArtistInfo__report").length ) {
+            $(".listenInfo .listenArtistInfo__report").replaceWith('<div id="mdb-artwork-input-wrapper"><input id="mdb-artwork-input" class="selectOnClick" type="text" value="'+origUrl+'" /><a id="mdb-artwork-link" href="'+origUrl+'" target="_blank">open artwork</a><img id="mdb-artwork-img" src="'+origUrl+'" style="display:none;" /></div>');
+        }
     }
 }
 

--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.04.23.1
+// @version      2026.05.04.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -166,12 +166,26 @@ waitForKeyElements(".listenArtworkWrapper", function( jNode ) {
     if( urlPath(2) && urlPath(2) != "sets" ) {
         //log( location.href );
 
-        // Artwork link tzo original
+        // Artwork link to original (legacy wrapper)
         var artworkWrapper = $(".listenArtworkWrapper"),
             artwork_url = $(".sc-artwork", artworkWrapper).html().replace(/.+&quot;(htt.+(?:jpg|png)).+/, "$1");
         log( artworkWrapper.html() );
         logVar( "artwork_url", artwork_url );
         if( typeof artwork_url  !== "undefined" ) {
+            append_artwork( artwork_url );
+        }
+    }
+});
+
+// Artwork link to original (new listenInfo wrapper)
+waitForKeyElements(".listenInfo .image span.sc-artwork[style*='background-image']", function( jNode ) {
+    if( urlPath(2) && urlPath(2) != "sets" ) {
+        var styleAttr = jNode.attr("style") || "",
+            artwork_url = styleAttr.replace(/.*background-image:\s*url\(["']?(https?:[^"')]+(?:jpg|png))["']?\).*/, "$1");
+
+        logVar( "artwork_url (listenInfo)", artwork_url );
+
+        if( typeof artwork_url !== "undefined" && artwork_url !== styleAttr ) {
             append_artwork( artwork_url );
         }
     }


### PR DESCRIPTION
### Motivation

- Support multiple SoundCloud DOM variants so artwork URLs are extracted and displayed whether the page uses the legacy `.listenArtworkWrapper` or the newer `.listenInfo .image` layout.
- Prevent errors when expected legacy wrappers are missing by guarding replacements.

### Description

- In `SoundCloud/script.funcs.js` updated `append_artwork` to check for the existence of `.listenArtworkWrapper` before replacing it, and added an `else if` branch to inject an input, link and hidden image into `.listenInfo .listenArtistInfo__report` when the legacy wrapper is not present.
- In `SoundCloud/script.user.js` bumped the userscript `@version` to `2026.05.04.2` and added a new `waitForKeyElements` handler that parses `background-image` style on `.listenInfo .image span.sc-artwork[...]` to extract `https?...jpg|png` URLs and call `append_artwork` for the new layout.
- Fixed a small comment typo (`tzo` → `to`).

### Testing

- No automated tests are configured for this userscript repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88a1bca0083209825b40db91e1455)