### PR TITLE
The Lot Radio: format first track cue as 00

### DIFF
--- a/The_Lot_Radio/script.user.js
+++ b/The_Lot_Radio/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         The Lot Radio (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.06.3
+// @version      2026.05.06.4
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -55,6 +55,14 @@ function formatTheLotRadioCue( totalSeconds, padTo ) {
     return pad( minutes, padTo );
 }
 
+function formatTheLotRadioTrackCue( track, padTo, isFirstTrack ) {
+    if( isFirstTrack && Math.round(track.timeSeconds / 60) === 1 ) {
+        return formatTheLotRadioCue( 0, padTo );
+    }
+
+    return formatTheLotRadioCue( track.timeSeconds, padTo );
+}
+
 function buildTheLotRadioTracklist( wrapperUl ) {
     var wrapper = $(wrapperUl);
 
@@ -104,7 +112,7 @@ function buildTheLotRadioTracklist( wrapperUl ) {
             nextTrack = tracks[index + 1];
 
         if( track.timeSeconds !== null ) {
-            line += "[" + formatTheLotRadioCue( track.timeSeconds, padTo ) + "] ";
+            line += "[" + formatTheLotRadioTrackCue( track, padTo, index === 0 ) + "] ";
         }
 
         if( track.artist !== "" ) {


### PR DESCRIPTION
### Motivation
- Ensure the generated tracklist shows the first cue as `00` when the first track would otherwise round to `01`, preventing incorrect minute labels for shows starting at 00:00:xx. 
- Keep the userscript version in sync with the date-based versioning policy by bumping the header version.

### Description
- Bumped the userscript header `@version` to `2026.05.06.4` in `The_Lot_Radio/script.user.js`.
- Added `formatTheLotRadioTrackCue(track, padTo, isFirstTrack)` which returns `00` for the first track when its rounded minute equals `1` and otherwise delegates to `formatTheLotRadioCue`.
- Updated tracklist line generation to call `formatTheLotRadioTrackCue` (passing `index === 0` for `isFirstTrack`) instead of calling `formatTheLotRadioCue` directly.

### Testing
- Ran a syntax check with `node --check The_Lot_Radio/script.user.js`, which completed successfully. 
- Ran `git diff --check` to validate whitespace and diff issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4da8b5008320984d8a7a1ea6b2f2)