### PR TITLE
Adapt The Lot Radio tracklist layout

### DIFF
--- a/TheLotRadio/script.user.js
+++ b/TheLotRadio/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         The Lot Radio (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.06.4
+// @version      2026.05.15.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -61,6 +61,44 @@ function formatTheLotRadioTrackCue( track, padTo, isFirstTrack ) {
     }
 
     return formatTheLotRadioCue( track.timeSeconds, padTo );
+}
+
+
+function ensureTheLotRadioTracklistLayout( wrapper, tlEditor ) {
+    var layout = wrapper.parent(".mdb-thelotradio-tracklist-layout");
+
+    wrapper.addClass("mdb-thelotradio-source-tracklist");
+    wrapper.css({
+        "display": "block",
+        "width": "100%",
+        "max-width": "100%"
+    });
+
+    tlEditor.css({
+        "box-sizing": "border-box",
+        "display": "block",
+        "flex": "0 0 100%",
+        "width": "100%",
+        "max-width": "100%",
+        "margin-bottom": "1rem"
+    });
+
+    if( !layout.length ) {
+        layout = $('<div class="mdb-thelotradio-tracklist-layout"></div>').css({
+            "box-sizing": "border-box",
+            "display": "block",
+            "flex": "0 0 100%",
+            "width": "100%",
+            "max-width": "100%"
+        });
+
+        wrapper.before( layout );
+        layout.append( tlEditor );
+        layout.append( wrapper );
+        return;
+    }
+
+    layout.prepend( tlEditor );
 }
 
 function buildTheLotRadioTracklist( wrapperUl ) {
@@ -147,7 +185,7 @@ function buildTheLotRadioTracklist( wrapperUl ) {
             .show();
 
         tlEditor.append( tlTextarea );
-        wrapper.before( tlEditor );
+        ensureTheLotRadioTracklistLayout( wrapper, tlEditor );
         fixTLbox( feedback, tlEditor );
         wrapper.addClass("mdb-processed-tracklist");
     }


### PR DESCRIPTION
### Motivation
- The Lot Radio page uses a flex-based `<ul>` which was squeezing the inserted MixesDB tracklist editor and causing layout issues. 
- The goal is to ensure the generated editor appears full-width above the source tracklist without being affected by the host page's flex rules. 
- Also apply the required userscript version bump for today. 

### Description
- Bump The Lot Radio userscript version to `2026.05.15.1`.
- Add `ensureTheLotRadioTracklistLayout(wrapper, tlEditor)` which creates or reuses a `.mdb-thelotradio-tracklist-layout` wrapper, forces the source `<ul>` and editor to full-width block styling, and prepends the editor into that layout.
- Mark the source tracklist with `.mdb-thelotradio-source-tracklist` and apply inline CSS via jQuery to avoid the page's flex squeezing.
- Route editor insertion through the new layout helper (`ensureTheLotRadioTracklistLayout`) instead of `wrapper.before(...)` before calling `fixTLbox`.

### Testing
- Ran `node --check TheLotRadio/script.user.js` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0737780f488320b839935065032653)