### PR TITLE
Fix The Lot Radio textarea positioning

### DIFF
--- a/TheLotRadio/script.user.js
+++ b/TheLotRadio/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         The Lot Radio (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.15.2
+// @version      2026.05.15.3
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -64,58 +64,32 @@ function formatTheLotRadioTrackCue( track, padTo, isFirstTrack ) {
 }
 
 
-function setTheLotRadioImportantStyles( element, styles ) {
-    $.each( styles, function( property, value ) {
-        element[0].style.setProperty( property, value, "important" );
-    });
-}
-
 function ensureTheLotRadioTracklistLayout( wrapper, tlEditor ) {
     var layout = wrapper.parent(".mdb-thelotradio-tracklist-layout");
 
     wrapper.addClass("mdb-thelotradio-source-tracklist");
-    setTheLotRadioImportantStyles( wrapper, {
-        "box-sizing": "border-box",
-        "clear": "both",
+    wrapper.css({
         "display": "block",
-        "float": "none",
-        "max-width": "100%",
-        "position": "static",
-        "transform": "none",
-        "width": "100%"
+        "width": "100%",
+        "max-width": "100%"
     });
 
-    setTheLotRadioImportantStyles( tlEditor, {
+    tlEditor.css({
         "box-sizing": "border-box",
-        "clear": "both",
         "display": "block",
-        "float": "none",
         "flex": "0 0 100%",
-        "margin-bottom": "1rem",
-        "max-width": "100%",
-        "position": "relative",
-        "transform": "none",
         "width": "100%",
-        "z-index": "1"
+        "max-width": "100%",
+        "margin-bottom": "1rem"
     });
 
     if( !layout.length ) {
-        layout = $('<div class="mdb-thelotradio-tracklist-layout"></div>');
-        setTheLotRadioImportantStyles( layout, {
+        layout = $('<div class="mdb-thelotradio-tracklist-layout"></div>').css({
             "box-sizing": "border-box",
-            "clear": "both",
-            "display": "flex",
+            "display": "block",
             "flex": "0 0 100%",
-            "flex-direction": "column",
-            "float": "none",
-            "gap": "1rem",
-            "grid-column": "1 / -1",
-            "max-width": "100%",
-            "min-width": "0",
-            "overflow": "visible",
-            "position": "relative",
-            "transform": "none",
-            "width": "100%"
+            "width": "100%",
+            "max-width": "100%"
         });
 
         wrapper.before( layout );
@@ -124,12 +98,13 @@ function ensureTheLotRadioTracklistLayout( wrapper, tlEditor ) {
         return;
     }
 
-    setTheLotRadioImportantStyles( layout, {
-        "display": "flex",
-        "flex-direction": "column",
-        "gap": "1rem"
-    });
     layout.prepend( tlEditor );
+}
+
+function keepTheLotRadioTextareaInFlow( tlEditor ) {
+    tlEditor.find("textarea.mixesdb-TLbox")
+        .removeClass("fixed")
+        .css("position", "");
 }
 
 function buildTheLotRadioTracklist( wrapperUl ) {
@@ -218,6 +193,7 @@ function buildTheLotRadioTracklist( wrapperUl ) {
         tlEditor.append( tlTextarea );
         ensureTheLotRadioTracklistLayout( wrapper, tlEditor );
         fixTLbox( feedback, tlEditor );
+        keepTheLotRadioTextareaInFlow( tlEditor );
         wrapper.addClass("mdb-processed-tracklist");
     }
 }


### PR DESCRIPTION
### Motivation
- The Lot Radio site (or React) can add a `fixed` class to the generated textarea which applies `.fixed { position: fixed; }` and pulls the textarea out of flow, causing overlap with other content.
- A previous change introduced stronger `!important` style normalization that overrode some page layout but still allowed the textarea to be positioned out of flow.
- The goal is to keep the injected tracklist editor layout simple and ensure the textarea remains in normal document flow so it does not overlap page content.

### Description
- Bump the userscript version to `2026.05.15.3` in `TheLotRadio/script.user.js`.
- Reverted the previous important-based normalization and simplified layout adjustments in `ensureTheLotRadioTracklistLayout` by using `wrapper.css()` and `tlEditor.css()` instead of forcing styles with `!important`.
- Added `keepTheLotRadioTextareaInFlow` which finds the generated textarea (`textarea.mixesdb-TLbox`), removes the `fixed` class, and clears its `position` style.
- Call `keepTheLotRadioTextareaInFlow` immediately after `fixTLbox(...)` so the textarea cannot be pulled out of flow by the site's `.fixed` rule.

### Testing
- Ran `node --check TheLotRadio/script.user.js` to validate there are no syntax errors, and it succeeded.
- Ran `git diff --check` to verify no whitespace or diff issues, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d73871c83209821b3648d5d626e)