### PR TITLE
Prevent toolkit edit flow from changing complete tracklist to incomplete

### DIFF
--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.19.1
+// @version      2026.05.26.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -11,7 +11,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-TrackId.net_109
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-TrackId.net_85
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-TrackId.net_86
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Tracklist_Cue_Switcher/script.funcs.js?v_2
 // @include      http*trackid.net*
 // @include      http*mixesdb.com/w/*

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -1249,12 +1249,18 @@ d.ready(function () {
         var textarea = $("textarea#wpTextbox1");
 
         if (textarea.length) {
-            textarea.val(
-                textarea.val().replace(
-                    "[[Category:Tracklist: none]]",
-                    "[[Category:Tracklist: " + siteHasTl + "]]"
-                )
-            );
+            var currentText = textarea.val(),
+                hasTracklistCompleteCategory = currentText.indexOf("[[Category:Tracklist: complete]]") !== -1,
+                skipCategoryUpdate = (siteHasTl == "incomplete" && hasTracklistCompleteCategory);
+
+            if( !skipCategoryUpdate ) {
+                textarea.val(
+                    currentText.replace(
+                        "[[Category:Tracklist: none]]",
+                        "[[Category:Tracklist: " + siteHasTl + "]]"
+                    )
+                );
+            }
 
             $("#afterTextbox1 a.button-after").removeClass("op1");
 


### PR DESCRIPTION
### Motivation
- EDIT links opened from the TrackId.net toolkit could pass `siteHasTl=incomplete` and overwrite a page that already had `[[Category:Tracklist: complete]]`, effectively downgrading the tracklist category, so the edit-page flow must avoid that.

### Description
- Added a guard in `includes/toolkit.js` so the edit-page handler detects `[[Category:Tracklist: complete]]` in the textarea and skips replacing `[[Category:Tracklist: none]]` when `siteHasTl == "incomplete"`.
- Bumped the TrackId.net userscript `@version` to `2026.05.26.1` and updated its `@require` cache-buster to `includes/toolkit.js?v-TrackId.net_86` to pick up the change.
- Left existing button highlighting behavior intact and made no other functional changes.

### Testing
- Ran `rg` and `sed` to locate and inspect the modified block in `includes/toolkit.js` and confirmed the new `skipCategoryUpdate` logic is present and correct.
- Ran `git diff` to verify the working diff contains only the intended edits and completed `git commit` successfully. 
- All automated checks/commands executed during the change completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1559136c088320828a75fab7e67834)