### PR TITLE
Skip category rewrite and button highlight when page already 'Tracklist: complete'

### DIFF
--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.13.2
+// @version      2026.05.26.1
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Userscripts_Helper_13
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_5
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_6
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -1262,13 +1262,15 @@ d.ready(function () {
                 );
             }
 
-            $("#afterTextbox1 a.button-after").removeClass("op1");
+            if( !skipCategoryUpdate ) {
+                $("#afterTextbox1 a.button-after").removeClass("op1");
 
-            var buttonSelector = siteHasTl == "incomplete" ? "a#button-after-TLi" : "a#button-after-TLc",
-                targetButton = $(buttonSelector);
+                var buttonSelector = siteHasTl == "incomplete" ? "a#button-after-TLi" : "a#button-after-TLc",
+                    targetButton = $(buttonSelector);
 
-            if (targetButton.length) {
-                targetButton.addClass("op1");
+                if (targetButton.length) {
+                    targetButton.addClass("op1");
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation

- Prevent toolkit/TID edit links from downgrading or visually marking pages that already contain `[[Category:Tracklist: complete]]`, so the edit experience preserves existing complete-tracklist pages.

### Description

- In `includes/toolkit.js` the MixesDB edit-page block now skips both the category replacement and the button highlight when `siteHasTl` is `incomplete` but the page already contains `[[Category:Tracklist: complete]]` by gating the button-highlight code behind the same `skipCategoryUpdate` check.
- Updated the `MixesDB_Userscripts_Helper` userscript headers by bumping `@version` to `2026.05.26.1` and advancing the `toolkit.js` require query suffix to `v-MixesDB_Userscripts_Helper_6` to force consumers to load the change.
- Changes affect `includes/toolkit.js` and `MixesDB_Userscripts_Helper/script.user.js` only.

### Testing

- Inspected the modified ranges with `nl -ba includes/toolkit.js | sed -n '1245,1295p'` and `nl -ba MixesDB_Userscripts_Helper/script.user.js | sed -n '1,25p'`, which showed the intended edits and version bump, and both commands completed successfully. 
- Verified repository state with `git status --short` and committed the changes using `git commit`, both of which succeeded. 
- Created the PR metadata programmatically and it was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a155e7b5dec8320a9a2d4181e5fb5e4)