### PR TITLE
Fix siteHasTl button highlight when category update is skipped

### DIFF
--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.1
+// @version      2026.05.26.2
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.1
+// @version      2026.05.26.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -1262,15 +1262,17 @@ d.ready(function () {
                 );
             }
 
-            if( !skipCategoryUpdate ) {
-                $("#afterTextbox1 a.button-after").removeClass("op1");
+            if( skipCategoryUpdate ) {
+                return;
+            }
 
-                var buttonSelector = siteHasTl == "incomplete" ? "a#button-after-TLi" : "a#button-after-TLc",
-                    targetButton = $(buttonSelector);
+            $("#afterTextbox1 a.button-after").removeClass("op1");
 
-                if (targetButton.length) {
-                    targetButton.addClass("op1");
-                }
+            var buttonSelector = siteHasTl == "incomplete" ? "a#button-after-TLi" : "a#button-after-TLc",
+                targetButton = $(buttonSelector);
+
+            if (targetButton.length) {
+                targetButton.addClass("op1");
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent the toolkit from changing the `a.button-after-*` highlight state when a category update is intentionally skipped (e.g. `siteHasTl=incomplete` while the page already contains `[[Category:Tracklist: complete]]`).

### Description
- Add an early-return in `includes/toolkit.js` when `skipCategoryUpdate` is true so button highlighting is not touched. 
- Move the existing `#afterTextbox1 a.button-after` removal and target button `op1` add back into the non-skipped path. 
- Bump userscript versions to `2026.05.26.2` in `MixesDB_Userscripts_Helper/script.user.js` and `TrackId.net/script.user.js`.

### Testing
- Verified changes with `git diff` and committed them via `git commit` which succeeded. 
- Confirmed the updated block in `includes/toolkit.js` with `nl -ba includes/toolkit.js | sed -n '1246,1286p'` and verified version headers in the two userscript files with `nl -ba <file> | sed -n '1,12p'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15626ba2808320b2892db3422e0db2)