### PR TITLE
Tracklist_Merger: build TID merge URL on click

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.02.11.1
+// @version      2026.05.26.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -1081,13 +1081,14 @@ if( domain == "trackid.net" ) {
 
     // create merge link under tracklists
     waitForKeyElements("ul#tlEditor-feedback-topInfo", function( jNode ) {
-        var tl_candidate = $("textarea.mixesdb-TLbox").val();
+        var mergeLink = '<a href="https://www.mixesdb.com/w/MixesDB:Tests/Tracklist_Merger" target="_blank" rel="noopener">Open in Tracklist Merger</a>';
 
-        if( tl_candidate ) {
-            var mergeLink = '<a href="https://www.mixesdb.com/w/MixesDB:Tests/Tracklist_Merger?tl_candidate='+encodeURIComponent( tl_candidate )+'" target="_blank">Open in Tracklist Merger</a>';
+        add_mergeLink( jNode, mergeLink );
+    });
 
-            add_mergeLink( jNode, mergeLink );
-        }
+    $(document).on('click', '#mergeLink a', function() {
+        var tl_candidate = $("textarea.mixesdb-TLbox").val() || '';
+        this.href = "https://www.mixesdb.com/w/MixesDB:Tests/Tracklist_Merger?tl_candidate=" + encodeURIComponent( tl_candidate );
     });
 
     waitForKeyElements("ul#tlEditor-feedback-topInfo li.info_switchCueFormat", function( jNode ) {


### PR DESCRIPTION
### Motivation
- Ensure the "Open in Tracklist Merger" toolkit link uses the current textarea contents when clicked (so edits or actions like `Switch cue format` are included) instead of capturing the value at initialization.

### Description
- Move generation of the `tl_candidate` query parameter from initialization to a click handler so the `textarea.mixesdb-TLbox` value is read on click. 
- Keep the merge link always present under the top-info area and position it adjacent to the cue-format switch as before. 
- Bump userscript metadata version to `2026.05.26.1` and add `rel="noopener"` to the static link anchor.

### Testing
- Verified the code change with `git diff -- Tracklist_Merger/script.user.js` and confirmed the `tl_candidate` construction was moved to a click handler. (succeeded)
- Committed the change with `git commit` and inspected the file with `nl -ba Tracklist_Merger/script.user.js | sed -n '1,20p;1074,1105p'` to confirm the updated version and new click handler presence. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a156743edb48320ac3662082e834247)