### PR TITLE
Refactor duplicated siteHasTl edit-page logic into toolkit helper

### DIFF
--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.2
+// @version      2026.05.26.3
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Userscripts_Helper_13
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_6
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_7
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -1230,6 +1230,44 @@ waitForKeyElements("a.mdb-mixesdbLink.edit", function( jNode ) {
     }
 });
 
+function toolkit_applySiteHasTlToEditPage( siteHasTl="" ) {
+    if( /^(incomplete|complete)$/.test(siteHasTl) === false ) {
+        return;
+    }
+
+    var textarea = $("textarea#wpTextbox1");
+
+    if( !textarea.length ) {
+        return;
+    }
+
+    var currentText = textarea.val(),
+        hasTracklistCompleteCategory = currentText.indexOf("[[Category:Tracklist: complete]]") !== -1,
+        skipCategoryUpdate = (siteHasTl == "incomplete" && hasTracklistCompleteCategory);
+
+    if( !skipCategoryUpdate ) {
+        textarea.val(
+            currentText.replace(
+                "[[Category:Tracklist: none]]",
+                "[[Category:Tracklist: " + siteHasTl + "]]"
+            )
+        );
+    }
+
+    if( skipCategoryUpdate ) {
+        return;
+    }
+
+    $("#afterTextbox1 a.button-after").removeClass("op1");
+
+    var buttonSelector = siteHasTl == "incomplete" ? "a#button-after-TLi" : "a#button-after-TLc",
+        targetButton = $(buttonSelector);
+
+    if( targetButton.length ) {
+        targetButton.addClass("op1");
+    }
+}
+
 // MixesDB edit page: apply siteHasTl query parameter to categories and active button
 d.ready(function () {
     if (domain != "mixesdb.com" || typeof mw === "undefined" || !mw.config) {
@@ -1244,37 +1282,8 @@ d.ready(function () {
     if ((wgAction == "edit" || wgAction == "submit")
         && wgNamespaceNumber == 0
         && wgTitle != "Main Page"
-        && /^(incomplete|complete)$/.test(siteHasTl)
     ) {
-        var textarea = $("textarea#wpTextbox1");
-
-        if (textarea.length) {
-            var currentText = textarea.val(),
-                hasTracklistCompleteCategory = currentText.indexOf("[[Category:Tracklist: complete]]") !== -1,
-                skipCategoryUpdate = (siteHasTl == "incomplete" && hasTracklistCompleteCategory);
-
-            if( !skipCategoryUpdate ) {
-                textarea.val(
-                    currentText.replace(
-                        "[[Category:Tracklist: none]]",
-                        "[[Category:Tracklist: " + siteHasTl + "]]"
-                    )
-                );
-            }
-
-            if( skipCategoryUpdate ) {
-                return;
-            }
-
-            $("#afterTextbox1 a.button-after").removeClass("op1");
-
-            var buttonSelector = siteHasTl == "incomplete" ? "a#button-after-TLi" : "a#button-after-TLc",
-                targetButton = $(buttonSelector);
-
-            if (targetButton.length) {
-                targetButton.addClass("op1");
-            }
-        }
+        toolkit_applySiteHasTlToEditPage( siteHasTl );
     }
 });
 


### PR DESCRIPTION
### Motivation
- The same `siteHasTl` edit-page behavior (category replacement + active button selection) was duplicated across helper flows, so centralizing it avoids drift and makes it reusable for TID and MixesDB Userscripts Helper.

### Description
- Extracted the MixesDB edit-page `siteHasTl` behavior into `toolkit_applySiteHasTlToEditPage(siteHasTl)` in `includes/toolkit.js`.
- Replaced the inlined category/button mutation in the MixesDB edit-page ready handler with a call to the new helper.
- Bumped the MixesDB Userscripts Helper metadata version to `2026.05.26.3` and updated the `includes/toolkit.js` `@require` cache suffix from `_6` to `_7`.
- Removed the duplicated block from the ready handler and left a single reusable implementation in `includes/toolkit.js`.

### Testing
- Used `rg` pattern searches to confirm the inline block was removed and the helper function was added and referenced, and these checks succeeded.
- Inspected affected file fragments with `sed`/`nl` to verify the helper implementation and the userscript metadata updates were written as expected, and these inspections succeeded.
- No automated unit test suite exists in this repository to run against the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15801949588320902cc048fc545820)