### PR TITLE
Scope siteHasTl edit logic to TrackId userscript

### DIFF
--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.2
+// @version      2026.05.26.3
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.2
+// @version      2026.05.26.3
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -1232,6 +1232,10 @@ waitForKeyElements("a.mdb-mixesdbLink.edit", function( jNode ) {
 
 // MixesDB edit page: apply siteHasTl query parameter to categories and active button
 d.ready(function () {
+    if (scriptName != "TrackId.net") {
+        return;
+    }
+
     if (domain != "mixesdb.com" || typeof mw === "undefined" || !mw.config) {
         return;
     }


### PR DESCRIPTION
### Motivation
- Remove duplicated `siteHasTl` edit-page category/button logic from non-TID contexts so the behavior is only applied by the TrackId userscript.

### Description
- Add an early return guard in `includes/toolkit.js` so the MixesDB edit-page `siteHasTl` handling runs only when `scriptName == "TrackId.net"`, and bump the userscript versions to `2026.05.26.3` for `MixesDB_Userscripts_Helper/script.user.js` and `TrackId.net/script.user.js`.

### Testing
- Verified the change by inspecting diffs and file contents (checked the `siteHasTl` handler in `includes/toolkit.js` and the header `@version` fields in both userscripts), and the automated diff/inspection checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15835e49048320a92b2b6844dc47e0)