### PR TITLE
Tracklist Merger: support [X:XX] candidate cues

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.1
+// @version      2026.05.26.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -941,8 +941,10 @@ function run_merge( showDebug=false ) {
             tl_merged_arr.forEach(function(item){
                 if( item.type === "track" && item.cue ) {
                     if( item.cue.includes(':') ) {
-                        item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
-                    } else {
+                        if( /^\d+:\d+$/.test( item.cue ) ) {
+                            item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
+                        }
+                    } else if( /^\d+$/.test( item.cue ) ) {
                         item.cue = pad2( item.cue );
                     }
                 }
@@ -958,8 +960,10 @@ function run_merge( showDebug=false ) {
             tl_merged_arr.forEach(function(item){
                 if( item.type === "track" && item.cue ) {
                     if( item.cue.includes(':') ) {
-                        item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
-                    } else {
+                        if( /^\d+:\d+$/.test( item.cue ) ) {
+                            item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
+                        }
+                    } else if( /^\d+$/.test( item.cue ) ) {
                         item.cue = pad2( item.cue );
                     }
                 }

--- a/includes/global.js
+++ b/includes/global.js
@@ -998,10 +998,10 @@ function make_tlArr( tl ) {
                    .replace(/^\[[\d*\?*\:*]\]+\s*/, '');
 
         // Optional cue [00] at the start
-        var cueMatch = line.match(/^\[(\d*:*\d*:*\d*\?*)\]/);
+        var cueMatch = line.match(/^\[((?:\d|X|\?)+(?::(?:\d|X|\?){1,2}){0,2})\]/i);
         if (cueMatch) {
             row.cue = cueMatch[1];
-            line = line.replace(/^\[(\d+:*\d*:*\d*|\?)+\]\s*/, '');
+            line = line.replace(/^\[((?:\d|X|\?)+(?::(?:\d|X|\?){1,2}){0,2})\]\s*/i, '');
         }
 
         // Add trackText


### PR DESCRIPTION
### Motivation
- Candidate tracklists sometimes contain symbolic cue placeholders like `[X:XX]` (or mixes of digits, `X`, `?`) and those were being misparsed or converted incorrectly during merge.

### Description
- Relaxed the cue extraction regex in `make_tlArr` to accept mixed digit/`X`/`?` patterns such as `[X:XX]` and preserve them as `item.cue` in `includes/global.js`.
- Adjusted the cue-removal replacement in `make_tlArr` to match the new regex so shown cue tokens are properly stripped from the remaining track text.
- Added numeric guards in `run_merge` (in `Tracklist_Merger/script.user.js`) so conversion to minute-format only runs when the cue matches `^\d+:\d+$` or `^\d+$`, preventing malformed conversions of symbolic cues.
- Bumped the userscript version to `2026.05.26.2`.

### Testing
- Ran pattern searches (`rg`) and file diffs to verify changes were applied as intended and the `git diff` output showed the expected edits, which succeeded.
- Committed the changes with `git commit` which succeeded and recorded the changes to `includes/global.js` and `Tracklist_Merger/script.user.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15881c036c832099df256dff1b2d6b)