### PR TITLE
Improve cue parsing/validation and guard conversions in Tracklist Merger

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.1
+// @version      2026.05.26.3
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -941,8 +941,10 @@ function run_merge( showDebug=false ) {
             tl_merged_arr.forEach(function(item){
                 if( item.type === "track" && item.cue ) {
                     if( item.cue.includes(':') ) {
-                        item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
-                    } else {
+                        if( /^\d+:\d+$/.test( item.cue ) ) {
+                            item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
+                        }
+                    } else if( /^\d+$/.test( item.cue ) ) {
                         item.cue = pad2( item.cue );
                     }
                 }
@@ -958,8 +960,10 @@ function run_merge( showDebug=false ) {
             tl_merged_arr.forEach(function(item){
                 if( item.type === "track" && item.cue ) {
                     if( item.cue.includes(':') ) {
-                        item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
-                    } else {
+                        if( /^\d+:\d+$/.test( item.cue ) ) {
+                            item.cue = pad2( Math.round( durToSec_MS( item.cue ) / 60 ) );
+                        }
+                    } else if( /^\d+$/.test( item.cue ) ) {
                         item.cue = pad2( item.cue );
                     }
                 }

--- a/includes/global.js
+++ b/includes/global.js
@@ -994,14 +994,13 @@ function make_tlArr( tl ) {
         var row = { type: "track" };
 
         // Remove leading "#" or similar
-        line = line.replace(/^#\s*/, '')
-                   .replace(/^\[[\d*\?*\:*]\]+\s*/, '');
+        line = line.replace(/^#\s*/, '');
 
         // Optional cue [00] at the start
-        var cueMatch = line.match(/^\[(\d*:*\d*:*\d*\?*)\]/);
+        var cueMatch = line.match(/^\[((?:\d|X|\?)+(?::(?:\d|X|\?){1,2}){0,2})\]/i);
         if (cueMatch) {
             row.cue = cueMatch[1];
-            line = line.replace(/^\[(\d+:*\d*:*\d*|\?)+\]\s*/, '');
+            line = line.replace(/^\[((?:\d|X|\?)+(?::(?:\d|X|\?){1,2}){0,2})\]\s*/i, '');
         }
 
         // Add trackText


### PR DESCRIPTION
### Motivation
- Prevent invalid or ambiguous cue strings from being mis-parsed or wrongly converted when merging tracklists by tightening validation and parsing rules.
- Avoid inadvertently stripping bracketed tokens from track text and support common non-numeric cue markers like `X` and `?`.
- Bump the userscript version to reflect the fix.

### Description
- Bumped the userscript `@version` to `2026.05.26.3`.
- In `run_merge` tightened cue conversions by checking formats with explicit regexes (`/^\d+:\d+$/` and `/^\d+$/`) before converting or padding cues to avoid converting malformed or unexpected strings.
- In `includes/global.js` replaced the loose cue removal and matching with a more robust cue detection regex (`/^\[((?:\d|X|\?)+(?::(?:\d|X|\?){1,2}){0,2})\]/i`) and updated the subsequent replacement to use the same pattern so bracketed cues (including `X`/`?`) are handled correctly.
- Removed an overly broad `.replace()` that could remove other bracketed content unexpectedly and ensured `row.trackText` and `row.label` extraction remain correct.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15881c036c832099df256dff1b2d6b)