### PR TITLE
Tracklist Merger: normalize unknown cues to 0:?? in MM:SS lists

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.3
+// @version      2026.05.26.4
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -969,6 +969,17 @@ function run_merge( showDebug=false ) {
                 }
             });
         }
+    }
+
+    // If the merged list uses MM:SS cues, normalize unknown cue placeholders
+    // from "??" to "0:??" so they match the active cue format.
+    var mergedHasColon = tl_merged_arr.some(item => item.type === "track" && item.cue && item.cue.includes(':'));
+    if( mergedHasColon ) {
+        tl_merged_arr.forEach(function(item){
+            if( item.type === "track" && item.cue === "??" ) {
+                item.cue = "0:??";
+            }
+        });
     }
 
     var tl_merged = arr_toTlText( tl_merged_arr );


### PR DESCRIPTION
### Motivation
- Ensure unknown/gap cues follow the active cue format when the merged tracklist uses `MM:SS` style cues so `[??]` does not appear in colon-based lists (expected `[0:??]`).

### Description
- Add a post-merge normalization step in `Tracklist_Merger/script.user.js` that converts any track `cue === "??"` to `"0:??"` when the merged array contains colon-formatted cues, and bump the userscript version to `2026.05.26.4`.

### Testing
- Ran quick inspections and repository operations including `rg -n "@version|mergedHasColon|0:\?\?"`, `git status --short`, and `git add`/`git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a158d6312448320861a6d9583c24c3b)