### PR TITLE
Tracklist Merger: preserve cue minute prefix for unknown MM:SS cues

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.4
+// @version      2026.05.26.5
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -972,12 +972,23 @@ function run_merge( showDebug=false ) {
     }
 
     // If the merged list uses MM:SS cues, normalize unknown cue placeholders
-    // from "??" to "0:??" so they match the active cue format.
+    // from "??" to "X:??" where X is the last known minute prefix.
     var mergedHasColon = tl_merged_arr.some(item => item.type === "track" && item.cue && item.cue.includes(':'));
     if( mergedHasColon ) {
+        var lastCuePrefix = "0";
         tl_merged_arr.forEach(function(item){
-            if( item.type === "track" && item.cue === "??" ) {
-                item.cue = "0:??";
+            if( item.type !== "track" ) return;
+
+            if( item.cue === "??" ) {
+                item.cue = lastCuePrefix + ":??";
+                return;
+            }
+
+            if( item.cue && item.cue.includes(':') ) {
+                var cuePrefix = item.cue.split(':')[0];
+                if( /^\d+$/.test(cuePrefix) ) {
+                    lastCuePrefix = cuePrefix;
+                }
             }
         });
     }


### PR DESCRIPTION
### Motivation
- Fix a bug where unknown MM:SS cue placeholders were always normalized to `0:??` instead of preserving the last known minute prefix when the candidate uses `MM:SS` style cues.

### Description
- Replace the previous hardcoded normalization so unknown cues (`"??"`) become `X:??` where `X` is tracked from the most recent valid `MM` prefix in the merged list.
- Skip non-track entries when scanning for the last known minute prefix so surrounding gaps and labels do not affect the prefix selection.
- Only perform this behavior when the merged list uses `MM:SS` style cues (contains a colon).
- Bump the userscript version to `2026.05.26.5`.

### Testing
- Ran a token/regex scan with `rg -n "\?\?|cue|X:XX|\[\?\?\]|fill|gap" Tracklist_Merger/script.user.js` to locate relevant code paths and it returned expected matches.
- Performed an automated in-place replacement using a small `python` script to patch the file and then inspected changes with `git diff -- Tracklist_Merger/script.user.js`, both of which succeeded. 
- Committed the change with `git commit` to record the fix, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15934837908320ac1c749457b65f58)