### PR TITLE
Normalize MM:SS unknown cue placeholders (convert `??` → `X:??`) and bump version

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.5
+// @version      2026.05.27.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -979,7 +979,7 @@ function run_merge( showDebug=false ) {
         tl_merged_arr.forEach(function(item){
             if( item.type !== "track" ) return;
 
-            if( item.cue === "??" ) {
+            if( typeof item.cue === "string" && item.cue.trim() === "??" ) {
                 item.cue = lastCuePrefix + ":??";
                 return;
             }


### PR DESCRIPTION
### Motivation
- Fix a bug where unknown cue placeholders written as `??` (including when padded with whitespace) were not normalized to `X:??` in MM:SS mode, causing merged tracklists to show bare `??` instead of the expected minute-prefixed placeholders.

### Description
- Normalize unknown cue placeholders by checking `typeof item.cue === "string" && item.cue.trim() === "??"` and converting them to `lastCuePrefix + ":??"` in MM:SS mode.
- Preserve the existing logic that carries forward the last known minute prefix (`lastCuePrefix`) so subsequent unknown cues become `X:??` as expected.
- Bump the userscript version to `2026.05.27.1`.

### Testing
- Ran automated repository searches with `rg` and inspected the changed file with `sed`/`nl` to verify the new check and that the `??` → `X:??` conversion is applied where appropriate, and no other occurrences were affected; checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16af53c67c8320b8bc1a9b07195399)