### PR TITLE
Tracklist Merger: preserve minute prefix for missing cues

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.27.1
+// @version      2026.05.27.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -971,15 +971,15 @@ function run_merge( showDebug=false ) {
         }
     }
 
-    // If the merged list uses MM:SS cues, normalize unknown cue placeholders
-    // from "??" to "X:??" where X is the last known minute prefix.
+    // If the merged list uses MM:SS cues, normalize unknown/missing cues
+    // to "X:??" where X is the last known minute prefix.
     var mergedHasColon = tl_merged_arr.some(item => item.type === "track" && item.cue && item.cue.includes(':'));
     if( mergedHasColon ) {
         var lastCuePrefix = "0";
         tl_merged_arr.forEach(function(item){
             if( item.type !== "track" ) return;
 
-            if( typeof item.cue === "string" && item.cue.trim() === "??" ) {
+            if( !item.cue || (typeof item.cue === "string" && item.cue.trim() === "??") ) {
                 item.cue = lastCuePrefix + ":??";
                 return;
             }


### PR DESCRIPTION
### Motivation
- Ensure merged tracklists that use `MM:SS` cues keep minute context for tracks with no cue by filling them as `X:??` (using the last known minute prefix) instead of leaving them blank and rendering as `[??]`.

### Description
- Treat empty/missing cue fields the same as explicit `"??"` in `run_merge` so they are normalized to `lastCuePrefix + ":??"` when the merged list uses `MM:SS` cues, and bump userscript version to `2026.05.27.2` in `Tracklist_Merger/script.user.js`.

### Testing
- Applied the patch and ran repository checks (`git status`, `git diff`) and committed the change with message `Tracklist Merger: preserve minute prefix for missing cues`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b1238c20832089e56ee7b4ce9881)