### PR TITLE
Fix Tracklist Merger cue normalization from H:MM to [MM]

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.27.3
+// @version      2026.05.27.4
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -941,7 +941,7 @@ function normalizeCueToFormat(cue, format) {
     }
 
     var minsOnly = cue.includes(':')
-        ? Math.round( durToSec_MS(cue) / 60 )
+        ? parseInt(cue.split(':')[0], 10) * 60 + parseInt(cue.split(':')[1], 10)
         : parseInt(cue, 10);
     return String(minsOnly).padStart(format.cueDigits, '0');
 }


### PR DESCRIPTION
### Motivation
- Candidate cues in `H:MM` format were being converted to minute-only original cues by treating `H:MM` like `MM:SS` (via seconds conversion), producing incorrect outputs such as `[00]`/`[01]` instead of the expected minute values (e.g. `0:19` → `19`).

### Description
- Update `normalizeCueToFormat` in `Tracklist_Merger/script.user.js` to parse colon cues as `H:MM` and compute minute values with `parseInt(cue.split(':')[0],10) * 60 + parseInt(cue.split(':')[1],10)` when the target format is minute-only. 
- Keep existing behavior when the target format includes seconds, and preserve the rest of the cue-normalization flow. 
- Bump userscript version to `2026.05.27.4` in the script header.

### Testing
- Committed the change with `git` and verified the commit succeeded (commit message: "Fix H:MM cue conversion when normalizing to minute cues").
- Inspected the updated file with `nl`/`sed` to confirm the modified `normalizeCueToFormat` logic and header version, with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b6596560832082db4a0b64039e9e)