### PR TITLE
Tracklist Cue Switcher: persist clicked cue format as default

### DIFF
--- a/Tracklist_Cue_Switcher/script.user.js
+++ b/Tracklist_Cue_Switcher/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Cue Switcher (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.02.11.2
+// @version      2026.05.27.1
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234
@@ -301,26 +301,14 @@ function getTargetFormatFromCue(cue) {
     return null;
 }
 
-function rememberTracklistPreferredFormatForMode($tracklist, mode) {
-    var selectedFormat = null;
+function rememberPreferredFormatFromClickedCue(linkEl, mode) {
+    // Only persist on the two single-format modes.
+    // Mode 2 intentionally shows both formats and should not become default.
+    if (mode !== 0 && mode !== 1) return;
 
-    $tracklist.find("a.mdbCueToggle").each(function () {
-        var $link = $(this);
-        var originalCue = String($link.data("originalCue") || getCueFromToggleText($link.text()) || "").trim();
-        var alternateCue = String($link.data("alternateCue") || "").trim();
-        var cue = null;
-
-        if (mode === 0) {
-            cue = originalCue;
-        } else if (mode === 1) {
-            cue = alternateCue || originalCue;
-        }
-
-        if (!cue) return;
-
-        selectedFormat = getTargetFormatFromCue(cue);
-        if (selectedFormat) return false;
-    });
+    var $link = $(linkEl);
+    var displayedCue = getCueFromToggleText($link.text());
+    var selectedFormat = getTargetFormatFromCue(displayedCue);
 
     if (selectedFormat) {
         storePreferredCueFormat(selectedFormat);
@@ -466,8 +454,9 @@ $(document).on("click", "a.mdbCueToggle", function (e) {
         var $list = $(this);
         $list.data("cueDisplayMode", nextMode);
         applyTracklistCueMode($list, nextMode);
-        rememberTracklistPreferredFormatForMode($list, nextMode);
     });
+
+    rememberPreferredFormatFromClickedCue(this, nextMode);
 });
 
 


### PR DESCRIPTION
### Motivation
- Make the saved cue-display preference reflect the explicit format the user clicked (h:m vs mm) so subsequent pages open in the same cue format, and avoid saving the mixed-display mode as a default.

### Description
- Replace the scan-based `rememberTracklistPreferredFormatForMode` logic with `rememberPreferredFormatFromClickedCue(linkEl, mode)` which persists the format inferred from the clicked cue element only for single-format modes (`mode 0` and `mode 1`).
- Ensure `mode 2` (mixed display) is not persisted to localStorage so only concrete formats (`MM` or `HMM`) become the stored preference.
- Call `rememberPreferredFormatFromClickedCue(this, nextMode)` from the click handler after applying the mode to tracklists so the saved preference follows the user action.
- Bump userscript metadata `@version` to `2026.05.27.1` per repository convention.

### Testing
- Ran repository checks and file inspection with `git -C /workspace/userscripts status --short` and `git -C /workspace/userscripts diff -- Tracklist_Cue_Switcher/script.user.js`, which showed the intended changes.
- Verified file contents with `nl -ba Tracklist_Cue_Switcher/script.user.js | sed -n '1,40p;290,340p;440,480p'` and confirmed the new function and click handler call are present.
- Committed the change with `git -C /workspace/userscripts add Tracklist_Cue_Switcher/script.user.js && git -C /workspace/userscripts commit -m "Tracklist cue switcher: persist clicked cue format preference"` which completed successfully; there is no automated test suite for this userscript repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c41c29bc8320828fc07526b371dc)