### PR TITLE
TrackId.net: remember selected cue format across page loads

### DIFF
--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.27.1
+// @version      2026.05.27.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -1157,6 +1157,7 @@ function toggleTracklistTextareaCueFormat(targetFormat) {
 
             var buttonLabel_mm = "Switch cue format (mmm > h:m)";
             $("#switchCueFormat").text(buttonLabel_mm);
+            storeCueFormatPreference(nextFormat);
             selectTracklistTextarea();
             return;
         }


### PR DESCRIPTION
### Motivation
- The cue-format toggle did not persist the user’s selection when switching back to minutes-only (`mmm`), so subsequent pages could reopen using the previous format instead of the one last chosen.

### Description
- Save the cue format preference by calling `storeCueFormatPreference(nextFormat)` in the early-return path that restores the original minutes-only tracklist in `TrackId.net/script.user.js`.
- Bump the userscript version to `2026.05.27.2` in the script header.
- Change is limited to `TrackId.net/script.user.js` and only affects cue-format persistence logic.

### Testing
- Ran `rg -n "cue|mmm|h:m|format|localStorage|GM_setValue" TrackId.net/script.user.js Tracklist_Cue_Switcher/script.funcs.js` to locate relevant code and confirm changes, which succeeded.
- Inspected the modified region with `sed -n '1080,1235p' TrackId.net/script.user.js` to verify the new `storeCueFormatPreference` call, which succeeded.
- Verified header/version and insertion with `nl -ba TrackId.net/script.user.js | sed -n '1,20p;1148,1170p'`, which showed the updated `// @version` and the added preference store call and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c7df838c8320ba03d075bee8de69)