### PR TITLE
Fix Tracklist Merger diff input lag

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.29.1
+// @version      2026.05.29.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -35,6 +35,9 @@ const tid_minGap = 3;
 const similarityThreshold = 0.8;
 // Wait until typing pauses before rebuilding the expensive diff view.
 const diffInputDelay = 400;
+// Keep individual diff-rendering chunks short so large tracklists do not
+// monopolize the main thread while users continue editing.
+const diffRenderChunkSize = 5;
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -809,13 +812,21 @@ function calcSimilarity(a, b) {
       if (p.label) res += highlightWords(p.label, cls);
       return res;
     }
-    function findBestMatch(line, lines) {
-      var base = splitTrackLine(line);
-      var baseNorms = getTrackMatchNorms(base.text);
+    function buildTrackLineEntries(lines) {
+      return lines.map(function(line) {
+        var parts = splitTrackLine(line);
+        return {
+          line: line,
+          parts: parts,
+          norms: getTrackMatchNorms(parts.text)
+        };
+      });
+    }
+    function findBestMatchEntry(baseEntry, entries) {
+      var baseNorms = baseEntry.norms;
       var bestIdx = -1, bestScore = 0;
-      for (var i = 0; i < lines.length; i++) {
-        var other = splitTrackLine(lines[i]);
-        var otherNorms = getTrackMatchNorms(other.text);
+      for (var i = 0; i < entries.length; i++) {
+        var otherNorms = entries[i].norms;
         for (var b = 0; b < baseNorms.length; b++) {
           for (var o = 0; o < otherNorms.length; o++) {
             var score = calcSimilarity(otherNorms[o], baseNorms[b]);
@@ -825,80 +836,87 @@ function calcSimilarity(a, b) {
       }
       return { idx: bestIdx, score: bestScore };
     }
+    function renderDiffLine(entry, targetEntries, cls) {
+      if (entry.line === '') { return ''; }
+      if (entry.parts.text === '?' || entry.parts.text === '...') { return escapeHTML(entry.line); }
+
+      var match = findBestMatchEntry(entry, targetEntries);
+      if (match.score === 0 || match.idx === -1) {
+        return fullHighlight(entry.line, cls);
+      }
+
+      var target = targetEntries[match.idx].parts;
+      var res = escapeHTML(entry.parts.hash);
+      var cueHtml = wordDiff(entry.parts.cue, target.cue, cls); if (cueHtml) res += cueHtml;
+      res += wordDiff(entry.parts.text, target.text, cls);
+      var labelHtml = wordDiff(entry.parts.label, target.label, cls); if (labelHtml) res += labelHtml;
+      return res;
+    }
+    function scheduleDiffWork(callback) {
+      return window.setTimeout(callback, 0);
+    }
     $.fn.showTracklistDiffs = function(opts) {
       var text1 = opts.text1 || '';
       var text2 = opts.text2 || '';
       var text3 = opts.text3 || '';
+      var jobId = opts.jobId;
+      var isCurrent = opts.isCurrent || function(){ return true; };
+      var onComplete = opts.onComplete || function(){};
+      var setTimer = opts.setTimer || function(){};
       if (text1.slice(-1) !== '\n') { text1 += '\n'; }
       if (text2.slice(-1) !== '\n') { text2 += '\n'; }
       if (text3.slice(-1) !== '\n') { text3 += '\n'; }
-      var lines1 = text1.split('\n');
-      var lines2 = text2.split('\n');
-      var lines3 = text3.split('\n');
+
+      var entries1 = buildTrackLineEntries(text1.split('\n'));
+      var entries2 = buildTrackLineEntries(text2.split('\n'));
+      var entries3 = buildTrackLineEntries(text3.split('\n'));
+
       return this.each(function() {
-        var $container = $(this).empty();
-        var $row = $('<tr id="diffContainer">');
+        var container = this;
+        var columns = [
+          { source: entries1, target: entries2, cls: 'diff-removed', html: [], index: 0 },
+          { source: entries2, target: entries1, cls: 'diff-added', html: [], index: 0 },
+          { source: entries3, target: entries2, cls: 'diff-removed', html: [], index: 0 }
+        ];
+        var columnIndex = 0;
 
-        // Column 1: Original vs Merged
-        var html1 = lines1.map(function(line) {
-          if (line === '') { return ''; }
-          var p1 = splitTrackLine(line);
-          if (p1.text === '?' || p1.text === '...') { return escapeHTML(line); }
-          var match = findBestMatch(line, lines2);
-          if (match.score === 0 || match.idx === -1) {
-            return fullHighlight(line, 'diff-removed');
+        function renderChunk() {
+          if (!isCurrent(jobId)) { return; }
+
+          var linesRendered = 0;
+          while (columnIndex < columns.length && linesRendered < diffRenderChunkSize) {
+            var column = columns[columnIndex];
+            while (column.index < column.source.length && linesRendered < diffRenderChunkSize) {
+              column.html.push(renderDiffLine(column.source[column.index], column.target, column.cls));
+              column.index++;
+              linesRendered++;
+            }
+            if (column.index >= column.source.length) {
+              columnIndex++;
+            }
           }
-          var p2 = splitTrackLine(lines2[match.idx]);
-          var res = escapeHTML(p1.hash);
-          var cueHtml = wordDiff(p1.cue, p2.cue, 'diff-removed'); if (cueHtml) res += cueHtml;
-          res += wordDiff(p1.text, p2.text, 'diff-removed');
-          var labelHtml = wordDiff(p1.label, p2.label, 'diff-removed'); if (labelHtml) res += labelHtml;
-          return res;
-        }).join('\n');
-        $row.append($('<td>').append($('<pre>').html(html1)));
 
-        // Column 2: Merged vs Original
-        var html2 = lines2.map(function(line) {
-          if (line === '') { return ''; }
-          var p2 = splitTrackLine(line);
-          if (p2.text === '?' || p2.text === '...') { return escapeHTML(line); }
-          var match = findBestMatch(line, lines1);
-          if (match.score === 0 || match.idx === -1) {
-            return fullHighlight(line, 'diff-added');
+          if (columnIndex < columns.length) {
+            setTimer(scheduleDiffWork(renderChunk));
+            return;
           }
-          var p1 = splitTrackLine(lines1[match.idx]);
-          var res = escapeHTML(p2.hash);
-          var cueHtml = wordDiff(p2.cue, p1.cue, 'diff-added'); if (cueHtml) res += cueHtml;
-          res += wordDiff(p2.text, p1.text, 'diff-added');
-          var labelHtml = wordDiff(p2.label, p1.label, 'diff-added'); if (labelHtml) res += labelHtml;
-          return res;
-        }).join('\n');
-        $row.append($('<td>').append($('<pre>').html(html2)));
 
-        // Column 3: Candidate vs Merged
-        var html3 = lines3.map(function(line) {
-          if (line === '') { return ''; }
-          var p3 = splitTrackLine(line);
-          if (p3.text === '?' || p3.text === '...') { return escapeHTML(line); }
-          var match = findBestMatch(line, lines2);
-          if (match.score === 0 || match.idx === -1) {
-            return fullHighlight(line, 'diff-removed');
+          var $row = $('<tr id="diffContainer">');
+          columns.forEach(function(column) {
+            $row.append($('<td>').append($('<pre>').html(column.html.join('\n'))));
+          });
+          $row.find('pre').each(function() {
+            var $pre = $(this);
+            if (!$pre.text().endsWith('\n')) { $pre.append('\n'); }
+          });
+
+          if (isCurrent(jobId)) {
+            $(container).replaceWith($row);
+            onComplete();
           }
-          var p2 = splitTrackLine(lines2[match.idx]);
-          var res = escapeHTML(p3.hash);
-          var cueHtml = wordDiff(p3.cue, p2.cue, 'diff-removed'); if (cueHtml) res += cueHtml;
-          res += wordDiff(p3.text, p2.text, 'diff-removed');
-          var labelHtml = wordDiff(p3.label, p2.label, 'diff-removed'); if (labelHtml) res += labelHtml;
-          return res;
-        }).join('\n');
-        $row.append($('<td>').append($('<pre>').html(html3)));
+        }
 
-        $row.find('pre').each(function() {
-          var $pre = $(this);
-          if (!$pre.text().endsWith('\n')) { $pre.append('\n'); }
-        });
-
-        $container.replaceWith($row);
+        renderChunk();
       });
     };
   })(jQuery);
@@ -907,12 +925,27 @@ function calcSimilarity(a, b) {
 /*
  * run_diff
  */
-var diffInputTimer = null;
+var diffInputTimer = null,
+    diffRenderTimer = null,
+    diffRenderJobId = 0;
+
+function cancel_diff_render() {
+    diffRenderJobId++;
+    if( diffRenderTimer ) {
+        clearTimeout( diffRenderTimer );
+        diffRenderTimer = null;
+    }
+}
 
 function schedule_run_diff() {
     if( diffInputTimer ) {
         clearTimeout( diffInputTimer );
     }
+
+    // Stop any in-progress chunked diff immediately. Without this, a large
+    // stale render can continue to consume the main thread while editing the
+    // merged TLE textarea.
+    cancel_diff_render();
 
     diffInputTimer = setTimeout(function(){
         diffInputTimer = null;
@@ -925,24 +958,39 @@ function run_diff() {
         clearTimeout( diffInputTimer );
         diffInputTimer = null;
     }
+    cancel_diff_render();
 
     var text1 = $("#tl_original").val(),
         text2 = $("#merge_result_tle").val(),
-        text3 = $("#tl_candidate").val();
+        text3 = $("#tl_candidate").val(),
+        jobId = diffRenderJobId;
+
     if( text1 && text2 && text3 ) {
         if( text1 === text2 ) {
             $("#diffContainer").html('<td colspan="3" class="identical-msg">The merged tracklist is identical to the original.</td>');
+            adjust_columnWidths();
         } else {
-            $('#diffContainer').showTracklistDiffs({ text1, text2, text3 });
-            var pre = $('#diffContainer pre').first();
-            if( pre.length ) {
-                adjust_preHeights( pre );
-            }
+            $('#diffContainer').showTracklistDiffs({
+                text1: text1,
+                text2: text2,
+                text3: text3,
+                jobId: jobId,
+                isCurrent: function(id){ return id === diffRenderJobId; },
+                setTimer: function(timerId){ diffRenderTimer = timerId; },
+                onComplete: function(){
+                    diffRenderTimer = null;
+                    var pre = $('#diffContainer pre').first();
+                    if( pre.length ) {
+                        adjust_preHeights( pre );
+                    }
+                    adjust_columnWidths();
+                }
+            });
         }
     } else {
         $("#diffContainer td").remove();
+        adjust_columnWidths();
     }
-    adjust_columnWidths();
 }
 
 


### PR DESCRIPTION
### Motivation
- The diff view rebuild was single-shot and could monopolize the main thread, making `textarea#merge_result_tle` laggy while users continued editing after the first `diffInputDelay` fired.
- Repeated per-line parsing/normalization during matching amplified CPU cost for large tracklists, increasing perceived input lag.

### Description
- Bump userscript version to `2026.05.29.2` and add a new constant `diffRenderChunkSize` to limit work per render chunk in `Tracklist_Merger/script.user.js`.
- Cache parsed/normalized trackline entries via `buildTrackLineEntries` and switch matching to `findBestMatchEntry` to avoid repeated `splitTrackLine()` work.
- Replace monolithic diff rendering with a cancellable, chunked renderer in `$.fn.showTracklistDiffs` that uses `renderDiffLine`, `scheduleDiffWork`, `setTimer` and an `onComplete` hook to only replace the DOM when the current job finishes.
- Add cancellation controls (`diffRenderJobId`, `diffRenderTimer`, `cancel_diff_render`) and cancel any in-progress chunked render when `schedule_run_diff()` is invoked so stale renders stop immediately.

### Testing
- Ran `node --check Tracklist_Merger/script.user.js` to verify syntax (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194e5dd050832099fa39ec653ee015)