### PR TITLE
Normalize YouTube URLs for TrackId submissions

### DIFF
--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.26.3
+// @version      2026.06.02.1
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234
@@ -9,7 +9,7 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/MixesDB_Userscripts_Helper/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Userscripts_Helper_13
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Userscripts_Helper_14
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_6
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com

--- a/includes/global.js
+++ b/includes/global.js
@@ -198,7 +198,13 @@ function urlIsTidSubmitCompatible( thisUrl ) {
 
 // makeTidSubmitUrl
 function makeTidSubmitUrl( playerUrl, keywords="" ) {
-    var keyowrds = normalizeTitleForSearch( keywords );
+    var keyowrds = normalizeTitleForSearch( keywords ),
+        youtubeId = getYoutubeIdFromUrl( playerUrl );
+
+    if( youtubeId && /(?:^|\.)youtube(?:-nocookie)?\.com$|(?:^|\.)youtu\.be$/i.test( new URL( playerUrl, "https://www.youtube.com" ).hostname ) ) {
+        playerUrl = "https://www.youtube.com/watch?v=" + youtubeId;
+    }
+
     return 'https://trackid.net/submiturl?requestUrl='+encodeURIComponent( playerUrl )+'&keywords='+encodeURIComponent( keywords );
 }
 


### PR DESCRIPTION
### Motivation
- TrackId.net expects canonical YouTube watch URLs and some player variants (shortened, embed, nocookie, shorts) were previously forwarded unchanged which can break the submit flow. 
- The helper script version and cache key must be bumped so the updated `global.js` is distributed to users.

### Description
- Updated `makeTidSubmitUrl(playerUrl, keywords="")` in `includes/global.js` to extract a YouTube video ID using `getYoutubeIdFromUrl()` and, when the hostname is YouTube/`youtu.be`, rewrite `playerUrl` to the canonical `https://www.youtube.com/watch?v=<video-id>` using `new URL(playerUrl, "https://www.youtube.com")` as the base. 
- Bumped MixesDB Userscripts Helper metadata to `@version 2026.06.02.1` and updated its `global.js` require cache key to `v-MixesDB_Userscripts_Helper_14`. 
- Files changed: `includes/global.js` and `MixesDB_Userscripts_Helper/script.user.js`.

### Testing
- Ran `node --check includes/global.js` and `node --check MixesDB_Userscripts_Helper/script.user.js`, both checks succeeded. 
- Executed a Node smoke test that validates normalization for `youtu.be` short links, YouTube Shorts, `youtube-nocookie` embeds, standard `watch?v` URLs with extra params, and that non-YouTube URLs remain unchanged, and all cases passed. 
- Ran `git diff --check` as part of automated verification and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ecb1e543c8320ae98dd7e5c040275)