### PR TITLE
Add RA userscript and move RA player handling from Player Checker

### DIFF
--- a/Player_Checker/script.user.js
+++ b/Player_Checker/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Player Checker (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.03.23.2
+// @version      2026.06.07.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -14,8 +14,6 @@
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v-Player_Checker_1
 // @include      http*finn-johannsen.de*
 // @include      http*groove.de/*/*/*/*podcast*
-// @include      http*ra.co/news/*
-// @include      http*ra.co/podcast/*
 // @include      http*wearesoundspace.com/*
 // @include      http*toxicfamily.de/*/*/*/*
 // @noframes
@@ -38,8 +36,6 @@ https://finn-johannsen.de/2025/06/19/finn-johannsen-finn-johannsen-go-check-the-
 https://finn-johannsen.de/2025/12/04/finn-johannsen-hausmusik-57-2005/
 https://groove.de/2025/01/29/groove-podcast-447-albert-van-abbe/
 https://groove.de/2025/01/15/benjamin-roeder-charlie-groove-resident-podcast-60/
-https://ra.co/podcast/970
-https://de.ra.co/podcast/970
 https://www.toxicfamily.de/2024/09/26/tofa-nightshift-vom-25-09-2024-mit-grille-in-the-mix/
 https://wearesoundspace.com/mix386-luca-olivotto/
 https://wearesoundspace.com/in-focus-008-break-3000-dirt-crew-recordings/
@@ -69,9 +65,7 @@ var playerUrlItems_timeout = 500;
 
 // normalizeWebsiteTitles
 function normalizeWebsiteTitles( titleText ) {
-    return titleText
-               .replace( " ⟋ RA Podcast", "" )
-    ;
+    return titleText;
 }
 
 

--- a/RA/script.css
+++ b/RA/script.css
@@ -1,0 +1,42 @@
+.mdb-ra-artwork-info {
+    background-color: rgba(20, 20, 20, .7);
+    display: flex;
+    font-size: 12px;
+    line-height: 20px;
+    min-height: 20px;
+    width: 100%;
+}
+
+.mdb-ra-artwork-input,
+.mdb-ra-artwork-size {
+    background-color: rgba(0, 0, 0, 0.1);
+    box-sizing: border-box;
+    color: #fff;
+    height: 20px;
+    opacity: .75;
+}
+
+.mdb-ra-artwork-input {
+    border: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    padding: 0 3px;
+}
+
+.mdb-ra-artwork-input::selection {
+    background-color: #fc0 !important;
+    color: #fff;
+    opacity: 1;
+}
+
+.mdb-ra-artwork-size {
+    flex: 0 0 115px;
+    padding-right: 5px;
+    text-align: right;
+}
+
+.mdb-ra-artwork-size a {
+    color: #fff;
+    text-decoration: underline;
+}

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,0 +1,158 @@
+// ==UserScript==
+// @name         RA (by MixesDB)
+// @author       User:Martin@MixesDB (Subfader@GitHub)
+// @version      2026.06.07.1
+// @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
+// @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
+// @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
+// @updateURL    https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/RA/script.user.js
+// @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/RA/script.user.js
+// @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
+// @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-RA_1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-RA_1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v-RA_1
+// @match        *://ra.co/*
+// @match        *://*.ra.co/*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=ra.co
+// @noframes
+// @grant        unsafeWindow
+// @run-at       document-end
+// ==/UserScript==
+
+
+/*
+https://ra.co/news/*
+https://ra.co/podcast/970
+https://de.ra.co/podcast/970
+https://ra.co/events/2232716
+https://de.ra.co/events/2232716
+*/
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Load @ressource files with variables
+ * global.js URL needs to be changed manually
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+var cacheVersion = 1,
+    scriptName = "RA";
+
+loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
+loadRawCss( githubPath_raw + scriptName + "/script.css?v-" + cacheVersion );
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Basics
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+var playerUrlItems_timeout = 500;
+
+function normalizeRaTitles( titleText ) {
+    return titleText
+               .replace( " ⟋ RA Podcast", "" )
+    ;
+}
+
+function isRaEventPage() {
+    return /^\/events\/\d+(?:[/?#]|$)/.test( window.location.pathname );
+}
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Toolkit
+ * Moved from Player Checker.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+setTimeout(function() {
+    logFunc( "RA toolkit" );
+
+    var playerUrlItems = [ Math.max( $("iframe:visible").length, $("iframe").length ) ];
+    log_playerUrlItems_len( playerUrlItems, "after timeout ("+playerUrlItems_timeout+")" );
+
+    var max_toolboxIterations = Math.max( get_playerUrlItems_len( playerUrlItems ), 1 );
+    var titleText = normalizeRaTitles( $('meta[property="og:title"]').attr("content") || "" );
+
+    logVar( "max_toolboxIterations", max_toolboxIterations );
+
+    waitForKeyElements("iframe:not(.mdb-processed-toolkit)", function( jNode ) {
+        var iframe = jNode;
+        iframe.addClass("mdb-processed-toolkit");
+
+        getToolkit_fromIframe( iframe, "playerUrl", "detail page", "iframe.mdb-processed-toolkit:first", "before", titleText, "", max_toolboxIterations );
+    });
+}, playerUrlItems_timeout );
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Event artwork
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+// raImgproxyToOriginal()
+// Changes ra.co img urls like https://imgproxy.ra.co/_/quality:66/w:1442/rt:fill/aHR0cHM6Ly9pbWFnZXMucmEuY28vM2MyNGI0MTA1M2M4MGFmMjliOGVjNDMzODg4ODc3Mzc1M2UzZjAyNy5qcGc= to give the original (JPG or PNG, not webp)
+function raImgproxyToOriginal(url) {
+    const encoded = url.split("/").pop();
+    return atob(encoded);
+}
+
+function getRaArtworkSource( img ) {
+    var src = img.attr("src") || ( img[0] && img[0].currentSrc ) || "";
+
+    if( src.indexOf("imgproxy.ra.co") !== -1 ) {
+        return src;
+    }
+
+    var srcset = img.attr("srcset") || "";
+    if( srcset.indexOf("imgproxy.ra.co") === -1 ) {
+        return "";
+    }
+
+    var candidates = srcset.split(",").map(function( candidate ) {
+        return candidate.trim().split(/\s+/)[0];
+    }).filter(function( candidate ) {
+        return candidate.indexOf("imgproxy.ra.co") !== -1;
+    });
+
+    return candidates.length ? candidates[candidates.length - 1] : "";
+}
+
+function escapeHtmlAttr( text ) {
+    return text.replace(/&/g, "&amp;")
+               .replace(/"/g, "&quot;")
+               .replace(/</g, "&lt;")
+               .replace(/>/g, "&gt;");
+}
+
+function appendRaArtworkInfo( img ) {
+    if( !isRaEventPage() ) return;
+
+    var imgproxyUrl = getRaArtworkSource( img );
+    if( !imgproxyUrl ) return;
+
+    var origUrl = raImgproxyToOriginal( imgproxyUrl ),
+        imageType = origUrl.replace(/^.+\.([a-zA-Z]{3,4})(?:[?#].*)?$/, "$1").toUpperCase(),
+        escapedOrigUrl = escapeHtmlAttr( origUrl ),
+        wrapper = $('<div class="mdb-ra-artwork-info"><input class="mdb-ra-artwork-input selectOnClick" type="text" readonly value="'+escapedOrigUrl+'" /><div class="mdb-ra-artwork-size"><a href="'+escapedOrigUrl+'" target="_blank">loading…</a></div></div>');
+
+    img.after( wrapper );
+
+    var probe = new Image();
+    probe.onload = function() {
+        var artworkInfo = this.width +'&thinsp;x&thinsp;'+ this.height +' '+ imageType;
+        wrapper.find(".mdb-ra-artwork-size a").html( artworkInfo );
+    };
+    probe.src = origUrl;
+}
+
+waitForKeyElements("div[class*='FullWidthStyle'] > img:not(.mdb-ra-artwork-processed)", function( jNode ) {
+    jNode.addClass("mdb-ra-artwork-processed");
+    appendRaArtworkInfo( jNode );
+});


### PR DESCRIPTION
### Motivation
- Separate RA (ra.co) specific behavior from the generic Player Checker so RA pages can be handled and extended independently. 
- Expose original artwork URLs and image dimensions on RA event pages (like SoundCloud handling) to make image sourcing easier.

### Description
- Added a new `RA` userscript (`RA/script.user.js`) that matches `*.ra.co` and loads shared `global.js`/`toolkit.js` and SoundCloud API helpers, and set the userscript version to today. 
- Moved the RA-related iframe/player processing logic from `Player_Checker` into the new `RA` script and now call `getToolkit_fromIframe()` for RA iframes. 
- Implemented `raImgproxyToOriginal()` to decode imgproxy RA URLs and helper functions `getRaArtworkSource()`, `escapeHtmlAttr()` and `appendRaArtworkInfo()` to insert the original image URL and size/type after full-width artwork images. 
- Hooked the artwork insertion to FullWidth-style images using `waitForKeyElements` and added `RA/script.css` with styling for the artwork URL + size row. 
- Removed RA includes/handling from `Player_Checker/script.user.js` and bumped its version and normalized title handling accordingly.

### Testing
- Ran `node --check RA/script.user.js` which completed successfully. 
- Ran `node --check Player_Checker/script.user.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25573f52308320887d4313596f78f0)