### PR TITLE
Share artwork info wrapper helper

### DIFF
--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.07.3
+// @version      2026.06.07.4
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,7 +9,7 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/RA/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-RA_1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-RA_2
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-RA_1
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v-RA_1
 // @match        *://ra.co/*
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 3,
+var cacheVersion = 4,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -134,13 +134,6 @@ function getRaArtworkSource( img ) {
     return candidates.length ? candidates[candidates.length - 1] : "";
 }
 
-function escapeHtmlAttr( text ) {
-    return text.replace(/&/g, "&amp;")
-               .replace(/"/g, "&quot;")
-               .replace(/</g, "&lt;")
-               .replace(/>/g, "&gt;");
-}
-
 function isRaEventArtwork( img ) {
     return img.parent("[class*='FullWidthStyle']").length > 0;
 }
@@ -159,18 +152,14 @@ function appendRaArtworkInfo( img ) {
     if( !imgproxyUrl ) return;
 
     var origUrl = raImgproxyToOriginal( imgproxyUrl ),
-        imageType = origUrl.replace(/^.+\.([a-zA-Z]{3,4})(?:[?#].*)?$/, "$1").toUpperCase(),
-        escapedOrigUrl = escapeHtmlAttr( origUrl ),
-        wrapper = $('<div class="mdb-ra-artwork-info"><input class="mdb-ra-artwork-input selectOnClick" type="text" readonly value="'+escapedOrigUrl+'" /><div class="mdb-ra-artwork-size"><a href="'+escapedOrigUrl+'" target="_blank">loading…</a></div></div>');
+        wrapper = createArtworkInfoWrapper( origUrl, {
+            wrapperClass: "mdb-ra-artwork-info",
+            inputClass: "mdb-ra-artwork-input selectOnClick",
+            infoClass: "mdb-ra-artwork-size",
+            readonly: true
+        });
 
     img.after( wrapper );
-
-    var probe = new Image();
-    probe.onload = function() {
-        var artworkInfo = this.width +'&thinsp;x&thinsp;'+ this.height +' '+ imageType;
-        wrapper.find(".mdb-ra-artwork-size a").html( artworkInfo );
-    };
-    probe.src = origUrl;
 }
 
 waitForKeyElements("div[class*='FullWidthStyle'] > img:not(.mdb-ra-artwork-processed), img[src*='imgproxy.ra.co']:not(.mdb-ra-artwork-processed), img[srcset*='imgproxy.ra.co']:not(.mdb-ra-artwork-processed)", function( jNode ) {

--- a/SoundCloud/script.funcs.js
+++ b/SoundCloud/script.funcs.js
@@ -24,36 +24,26 @@ function append_artwork( artwork_url ) {
             $(".listenArtworkWrapper").replaceWith('<div id="mdb-artwork-wrapper"></div>');
             var imgWrapper = $("#mdb-artwork-wrapper");
 
-            imgWrapper.append('<div id="mdb-artwork-input-wrapper"><input id="mdb-artwork-input" class="selectOnClick" type="text" value="'+origUrl+'" /></div>');
+            imgWrapper.append( createArtworkInfoWrapper( origUrl, {
+                wrapperId: "mdb-artwork-input-wrapper",
+                inputId: "mdb-artwork-input",
+                inputClass: "selectOnClick",
+                infoId: "mdb-artwork-info"
+            }) );
             imgWrapper.prepend('<a class="mdb-artwork-img" href="'+origUrl+'" target="_blank"><img id="mdb-artwork-img" src="'+origUrl+'" /></a>');
 
         } else if( $(".listenInfo .listenArtistInfo__report").length ) {
-            $(".listenInfo .listenArtistInfo__report").replaceWith('<div id="mdb-artwork-input-wrapper"><input id="mdb-artwork-input" class="selectOnClick" type="text" value="'+origUrl+'" /><img id="mdb-artwork-img" src="'+origUrl+'" style="display:none;" /></div>');
+            var artworkInfoWrapper = createArtworkInfoWrapper( origUrl, {
+                wrapperId: "mdb-artwork-input-wrapper",
+                inputId: "mdb-artwork-input",
+                inputClass: "selectOnClick",
+                infoId: "mdb-artwork-info"
+            });
+            artworkInfoWrapper.append('<img id="mdb-artwork-img" src="'+origUrl+'" style="display:none;" />');
+            $(".listenInfo .listenArtistInfo__report").replaceWith( artworkInfoWrapper );
         }
     }
 }
-
-// Artwork info
-// runs after append_artwork() replaced the artwork
-waitForKeyElements("img#mdb-artwork-img", function( jNode ) {
-    var origUrl = jNode.attr("src").replace(/(\r\n|\n|\r)/gm, ""), // replace line breaks
-        imageType = origUrl.replace(/^.+\.([a-zA-Z]{3})/, "$1").toUpperCase();
-        //imageType = origUrl.substr( origUrl.length - 3 ).toUpperCase();
-    logVar( "origUrl", origUrl );
-
-    var img = new Image();
-    img.onload = function(){
-            var imageWidth = this.width,
-                imageHeight = this.height,
-                artworkInfo = imageWidth +'&thinsp;x&thinsp;'+ imageHeight +' '+ imageType;
-            logVar( "imageType", imageType );
-            logVar( "artworkInfo", artworkInfo );
-
-            $("#mdb-artwork-input-wrapper").append('<div id="mdb-artwork-info"><a href="'+origUrl+'" target="_blank">'+artworkInfo+'</a></div>');
-    };
-    img.src = origUrl;
-});
-
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *

--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.07.1
+// @version      2026.06.07.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,9 +9,9 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_33
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_34
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-SoundCloud_52
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_22
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_23
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v_2
 // @include      http*soundcloud.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=soundcloud.com

--- a/includes/global.js
+++ b/includes/global.js
@@ -81,6 +81,67 @@ function logArr( name, arr ) {
 //logVar( "is_safari", is_safari );
 
 
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Artwork funcs
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+function getArtworkImageType( artworkUrl ) {
+    var imageType = artworkUrl.replace(/^.+\.([a-zA-Z0-9]{3,4})(?:[?#].*)?$/, "$1");
+    return imageType === artworkUrl ? "" : imageType.toUpperCase();
+}
+
+function getArtworkInfoText( artworkUrl, imageWidth, imageHeight ) {
+    var imageType = getArtworkImageType( artworkUrl );
+    return imageWidth +'&thinsp;x&thinsp;'+ imageHeight + ( imageType ? ' '+ imageType : '' );
+}
+
+function loadArtworkInfo( artworkUrl, callback ) {
+    var img = new Image();
+    img.onload = function() {
+        callback( getArtworkInfoText( artworkUrl, this.width, this.height ) );
+    };
+    img.src = artworkUrl;
+}
+
+function createArtworkInfoWrapper( artworkUrl, options ) {
+    options = options || {};
+
+    var wrapper = $("<div>");
+    if( options.wrapperId ) wrapper.attr( "id", options.wrapperId );
+    if( options.wrapperClass ) wrapper.addClass( options.wrapperClass );
+
+    var input = $("<input>", {
+        type: "text",
+        value: artworkUrl
+    });
+    if( options.inputId ) input.attr( "id", options.inputId );
+    if( options.inputClass ) input.addClass( options.inputClass );
+    if( options.readonly ) input.prop( "readonly", true );
+
+    var link = $("<a>", {
+        href: artworkUrl,
+        target: "_blank"
+    }).text( options.loadingText || "loading…" );
+
+    var info = $("<div>");
+    if( options.infoId ) info.attr( "id", options.infoId );
+    if( options.infoClass ) info.addClass( options.infoClass );
+    info.append( link );
+
+    wrapper.append( input, info );
+
+    loadArtworkInfo( artworkUrl, function( artworkInfo ) {
+        link.html( artworkInfo );
+    });
+
+    return wrapper;
+}
+
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *
  * URL funcs


### PR DESCRIPTION
### Motivation
- Reduce duplicated artwork-info logic by centralising artwork URL input + dimension/type link rendering in a single helper in `includes/global.js`.
- Make RA and SoundCloud userscripts reuse the same helper to ensure consistent UI and reduce maintenance overhead.

### Description
- Add shared artwork helper functions to `includes/global.js`: `getArtworkImageType`, `getArtworkInfoText`, `loadArtworkInfo`, and `createArtworkInfoWrapper`.
- Refactor RA (`RA/script.user.js`) to use `createArtworkInfoWrapper()` instead of building wrapper markup and probe-loading image info manually, and bump the RA cache/version references and userscript `@version`.
- Refactor SoundCloud (`SoundCloud/script.funcs.js` and `SoundCloud/script.user.js`) to use the same shared wrapper and remove the duplicated artwork-info block, and bump SoundCloud cache/version references and userscript `@version`.
- Update resource query strings so the userscripts require the new `includes/global.js` version and updated `script.funcs.js` where applicable.

### Testing
- Ran `node --check includes/global.js && node --check SoundCloud/script.funcs.js && node --check RA/script.user.js && node --check SoundCloud/script.user.js`, which completed successfully. 
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2566c2c7848320a56968ca03d28ea6)