### PR TITLE
Fix SoundCloud artwork file type display

### DIFF
--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.07.2
+// @version      2026.06.07.3
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,9 +9,9 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_34
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_35
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-SoundCloud_52
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_23
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_24
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v_2
 // @include      http*soundcloud.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=soundcloud.com

--- a/includes/global.js
+++ b/includes/global.js
@@ -90,8 +90,14 @@ function logArr( name, arr ) {
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 function getArtworkImageType( artworkUrl ) {
-    var imageType = artworkUrl.replace(/^.+\.([a-zA-Z0-9]{3,4})(?:[?#].*)?$/, "$1");
-    return imageType === artworkUrl ? "" : imageType.toUpperCase();
+    artworkUrl = ( artworkUrl || "" ).replace(/(\r\n|\n|\r)/gm, "");
+
+    var urlPath = artworkUrl.split(/[?#]/)[0],
+        fileName = urlPath.split("/").pop(),
+        imageTypeMatches = fileName.match(/\.[a-zA-Z0-9]{3,4}(?=$|[^a-zA-Z0-9])/g) || [],
+        imageType = imageTypeMatches.pop();
+
+    return imageType ? imageType.replace(".", "").toUpperCase() : "";
 }
 
 function getArtworkInfoText( artworkUrl, imageWidth, imageHeight ) {


### PR DESCRIPTION
### Motivation
- After moving the artwork info helper into `includes/global.js`, `.mdb-artwork-info` stopped showing the image file type because the previous parser did not tolerate line breaks, query/hash parameters, size suffixes, or multiple-dot filenames.

### Description
- Add robust shared artwork helper functions to `includes/global.js`: `getArtworkImageType`, `getArtworkInfoText`, `loadArtworkInfo`, and `createArtworkInfoWrapper`, which sanitize input, extract the final filename, and parse extension-like tokens reliably.
- Update SoundCloud code to use the shared wrapper (`createArtworkInfoWrapper`) so artwork info text is populated via `includes/global.js` instead of duplicated inline parsing in the SoundCloud module.
- Bump the SoundCloud userscript `@version` and refresh the `@require` cache-busting parameters for `includes/global.js` and `SoundCloud/script.funcs.js`.

### Testing
- Ran `node --check includes/global.js` and `node --check SoundCloud/script.user.js`, both checks succeeded.
- Executed inline Node parsing checks covering URLs with query strings, hashes, newline suffixes, multiple-dot filenames, and colon-suffixed size tokens, and all cases returned the expected file types.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2569901d788320901bc52f6619dfff)