### PR TITLE
Add RA podcast tracklist formatter

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -41,3 +41,14 @@
     color: #fff;
     text-decoration: underline;
 }
+
+
+.mdb-ra-tracklist-editor {
+    margin: 8px 0 12px;
+}
+
+.mdb-ra-tracklist-editor #mixesdb-TLbox {
+    box-sizing: border-box;
+    font-size: 12px;
+    line-height: 1.4;
+}

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.07.4
+// @version      2026.06.07.5
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 4,
+var cacheVersion = 5,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -69,6 +69,68 @@ function isRaPodcastEpisodePage() {
 function isRaArtworkPage() {
     return isRaEventPage() || isRaPodcastEpisodePage();
 }
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Podcast tracklist
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+function getRaTracklistHeadline( tracklist ) {
+    var heading = tracklist.prevAll("span").filter(function() {
+        return $(this).text().trim().toLowerCase() === "tracklist";
+    }).first();
+
+    if( heading.length ) return heading;
+
+    return tracklist.closest("li").find("span").filter(function() {
+        return $(this).text().trim().toLowerCase() === "tracklist";
+    }).first();
+}
+
+function getRaTracklistText( tracklist ) {
+    return tracklist.text()
+                    .replace(/\u00A0/g, " ")
+                    .split("\n")
+                    .map(function( row ) {
+                        return row.trim().replace(/\s{2,}/g, " ");
+                    })
+                    .filter(function( row ) {
+                        return row !== "";
+                    })
+                    .map(function( row ) {
+                        return "# " + row;
+                    })
+                    .join("\n");
+}
+
+function appendRaTracklistEditor( tracklist ) {
+    if( !isRaPodcastEpisodePage() ) return;
+
+    var heading = getRaTracklistHeadline( tracklist );
+    if( !heading.length ) return;
+
+    var tl = getRaTracklistText( tracklist );
+    if( !tl ) return;
+
+    log( "RA tracklist before API:\n" + tl );
+
+    var res = apiTracklist( tl, "standard" ),
+        tlApi = res.text;
+
+    if( !tlApi ) return;
+
+    var editor = $(ta).addClass("mdb-ra-tracklist-editor");
+    tracklist.before( editor );
+    editor.find("#mixesdb-TLbox").val( tlApi );
+    fixTLbox( res.feedback, editor );
+}
+
+waitForKeyElements("ol[class*='Tracklist']:not(.mdb-ra-tracklist-processed)", function( jNode ) {
+    jNode.addClass("mdb-ra-tracklist-processed");
+    appendRaTracklistEditor( jNode );
+});
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *


### PR DESCRIPTION
### Motivation
- Provide a quick way to convert RA podcast tracklist blocks into MixesDB-ready formatted tracklists and insert an editable textarea between the "Tracklist" headline and the original list for podcast pages like `/podcast/<id>` (e.g. https://de.ra.co/podcast/1059). 

### Description
- Bump userscript version to `2026.06.07.5` and `cacheVersion` to `5` in `RA/script.user.js`.
- Add podcast tracklist handling: new helpers `getRaTracklistHeadline`, `getRaTracklistText`, and `appendRaTracklistEditor` that normalize RA tracklist rows, call the existing `apiTracklist` (MixesDB API), and insert the resulting textarea/editor before the list; the insertion is gated by `isRaPodcastEpisodePage()` and a processed marker. 
- Register a `waitForKeyElements` watcher for `ol[class*='Tracklist']` to detect and process tracklists automatically.
- Add CSS rules in `RA/script.css` for `.mdb-ra-tracklist-editor` and the editor textarea for spacing and readable font sizing.

### Testing
- Ran JavaScript syntax check with `node --check RA/script.user.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25818e65c083209c09d7b9eb992396)