### PR TITLE
Move RA tracklist section below embedded player

### DIFF
--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.07.9
+// @version      2026.06.08.1
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 9,
+var cacheVersion = 10,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -104,6 +104,40 @@ function getRaTracklistText( tracklist ) {
                     .join("\n");
 }
 
+function getRaPodcastPlayerIframe() {
+    return $("iframe.mdb-processed-toolkit[src*='soundcloud.com'], iframe[src*='soundcloud.com']").first();
+}
+
+function moveRaTracklistSectionBelowPlayer( tracklist ) {
+    if( !isRaPodcastEpisodePage() ) return;
+
+    var iframe = getRaPodcastPlayerIframe();
+    if( !iframe.length ) return;
+
+    var tracklistLi = tracklist.closest("li"),
+        tracklistSection = tracklistLi.children().filter(function() {
+            return $.contains( this, tracklist[0] );
+        }).first();
+
+    if( !tracklistSection.length ) {
+        tracklistSection = tracklist.parent();
+    }
+
+    if( tracklistSection.parent()[0] === iframe.parent()[0] && tracklistSection.index() > iframe.index() ) return;
+
+    iframe.after( tracklistSection );
+
+    if( tracklistLi.length && $.trim( tracklistLi.text() ) === "" && tracklistLi.children().length === 0 ) {
+        tracklistLi.remove();
+    }
+}
+
+function moveRaTracklistsBelowPlayer() {
+    $("ol.mdb-ra-tracklist-processed").each(function() {
+        moveRaTracklistSectionBelowPlayer( $(this) );
+    });
+}
+
 function appendRaTracklistEditor( tracklist ) {
     if( !isRaPodcastEpisodePage() ) return;
 
@@ -124,6 +158,8 @@ function appendRaTracklistEditor( tracklist ) {
     tracklist.before( editor );
     editor.find("#mixesdb-TLbox").val( tlApi );
     fixTLbox( res.feedback, editor );
+
+    moveRaTracklistSectionBelowPlayer( tracklist );
 }
 
 waitForKeyElements("ol[class*='Tracklist']:not(.mdb-ra-tracklist-processed)", function( jNode ) {
@@ -156,6 +192,7 @@ setTimeout(function() {
         iframe.addClass("mdb-processed-toolkit");
 
         getToolkit_fromIframe( iframe, "playerUrl", "detail page", "iframe.mdb-processed-toolkit:first", "before", titleText, "", max_toolboxIterations );
+        moveRaTracklistsBelowPlayer();
     });
 }, playerUrlItems_timeout );
 


### PR DESCRIPTION
### Motivation

- Ensure the podcast tracklist (headline, textarea editor and original list) appears directly under the embedded player so the editor and tracklist are visible next to the player on RA podcast pages. 
- Refresh loaded CSS/assets for this userscript by bumping its cache and version so deployments pick up the change.

### Description

- Bumped the userscript `@version` to `2026.06.08.1` and incremented `cacheVersion` to `10` to force refreshed assets and follow the userscript versioning policy.  
- Added `getRaPodcastPlayerIframe()`, `moveRaTracklistSectionBelowPlayer()` and `moveRaTracklistsBelowPlayer()` to locate the SoundCloud iframe and move the entire tracklist section (container that contains the `ol` tracklist, its headline and the generated editor textarea) immediately after the iframe.  
- Invoke the move after creating the tracklist editor in `appendRaTracklistEditor()` and again after iframe processing in the toolkit flow so the relocation succeeds regardless of DOM load order.  
- Remove now-empty source `<li>` elements when their contents are moved to avoid leaving empty placeholders.

### Testing

- Ran syntax validation with `node --check RA/script.user.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268a8842ec8320a8c6db6de08965cc)