### PR TITLE
Add RA event venue copy button

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -45,3 +45,25 @@
 .mdb-ra-tracklist-editor {
     margin-top: -10px;
 }
+.mdb-ra-venue-copy-button {
+    align-items: center;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 3px;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    height: 20px;
+    justify-content: center;
+    line-height: 1;
+    margin-left: 6px;
+    padding: 0 5px;
+    vertical-align: middle;
+}
+
+.mdb-ra-venue-copy-button:hover,
+.mdb-ra-venue-copy-button:focus {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.7);
+}

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.08.2
+// @version      2026.06.08.3
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 10,
+var cacheVersion = 11,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -69,6 +69,76 @@ function isRaPodcastEpisodePage() {
 function isRaArtworkPage() {
     return isRaEventPage() || isRaPodcastEpisodePage();
 }
+
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * Event venue copy button
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+function copyRaTextToClipboard( text ) {
+    if( navigator.clipboard && navigator.clipboard.writeText ) {
+        return navigator.clipboard.writeText( text );
+    }
+
+    var textarea = $("<textarea>")
+        .val( text )
+        .attr( "readonly", true )
+        .css({
+            left: "-9999px",
+            position: "fixed",
+            top: "-9999px"
+        })
+        .appendTo( document.body );
+
+    textarea[0].select();
+    document.execCommand( "copy" );
+    textarea.remove();
+
+    return Promise.resolve();
+}
+
+function showRaCopyDialog( message ) {
+    window.alert( message );
+}
+
+function appendRaVenueCopyButton( venueLink ) {
+    if( !isRaEventPage() ) return;
+    if( venueLink.hasClass( "mdb-ra-venue-copy-processed" ) ) return;
+
+    var venueName = $.trim( venueLink.text() );
+    if( !venueName ) return;
+
+    venueLink.addClass( "mdb-ra-venue-copy-processed" );
+
+    var button = $("<button>")
+        .attr({
+            "aria-label": "Copy venue name",
+            title: "Copy venue name",
+            type: "button"
+        })
+        .addClass( "mdb-ra-venue-copy-button" )
+        .text( "⧉" );
+
+    button.on( "click", function( event ) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        var currentVenueName = $.trim( venueLink.text() );
+        if( !currentVenueName ) return;
+
+        copyRaTextToClipboard( currentVenueName ).then(function() {
+            showRaCopyDialog( currentVenueName + " copied!" );
+        });
+    });
+
+    venueLink.after( button );
+}
+
+waitForKeyElements("a[data-pw-test-id='event-venue-link']:not(.mdb-ra-venue-copy-processed)", function( jNode ) {
+    appendRaVenueCopyButton( jNode );
+});
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *


### PR DESCRIPTION
### Motivation
- Make it easy to copy the venue name from RA event pages (e.g. `La Forgiatura`) for paste into other tools or the wiki. 
- Respect existing userscript versioning and cache invalidation so the new CSS is picked up.

### Description
- Added an event-venue copy button inserted after `a[data-pw-test-id='event-venue-link']` using `waitForKeyElements`, skipping already-processed links via `.mdb-ra-venue-copy-processed`.
- Implemented `copyRaTextToClipboard()` with a `navigator.clipboard` primary path and a textarea fallback that calls `document.execCommand('copy')` for compatibility.
- Shows a simple modal confirmation using `window.alert()` with the copied text (e.g. `La Forgiatura copied!`).
- Added `.mdb-ra-venue-copy-button` CSS for inline glyph appearance and hover/focus states, and incremented `cacheVersion` and the userscript `@version` to fetch the updated stylesheet.

### Testing
- Ran `node --check RA/script.user.js` and it passed without errors.
- Ran `git diff --check` and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26aebeaa68832089305b5a769fc5dd)