### PR TITLE
Move RA venue copy button to shared global helper

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -45,25 +45,3 @@
 .mdb-ra-tracklist-editor {
     margin-top: -10px;
 }
-.mdb-ra-venue-copy-button {
-    align-items: center;
-    background: transparent;
-    border: 1px solid rgba(255, 255, 255, 0.35);
-    border-radius: 3px;
-    color: #fff;
-    cursor: pointer;
-    display: inline-flex;
-    font: inherit;
-    height: 20px;
-    justify-content: center;
-    line-height: 1;
-    margin-left: 6px;
-    padding: 0 5px;
-    vertical-align: middle;
-}
-
-.mdb-ra-venue-copy-button:hover,
-.mdb-ra-venue-copy-button:focus {
-    background: rgba(255, 255, 255, 0.16);
-    border-color: rgba(255, 255, 255, 0.7);
-}

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.08.3
+// @version      2026.06.08.4
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,7 +9,7 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/RA/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-RA_2
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-RA_3
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-RA_1
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v-RA_1
 // @match        *://ra.co/*
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 11,
+var cacheVersion = 12,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -77,66 +77,20 @@ function isRaArtworkPage() {
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-function copyRaTextToClipboard( text ) {
-    if( navigator.clipboard && navigator.clipboard.writeText ) {
-        return navigator.clipboard.writeText( text );
-    }
-
-    var textarea = $("<textarea>")
-        .val( text )
-        .attr( "readonly", true )
-        .css({
-            left: "-9999px",
-            position: "fixed",
-            top: "-9999px"
-        })
-        .appendTo( document.body );
-
-    textarea[0].select();
-    document.execCommand( "copy" );
-    textarea.remove();
-
-    return Promise.resolve();
-}
-
-function showRaCopyDialog( message ) {
-    window.alert( message );
-}
-
 function appendRaVenueCopyButton( venueLink ) {
     if( !isRaEventPage() ) return;
-    if( venueLink.hasClass( "mdb-ra-venue-copy-processed" ) ) return;
 
-    var venueName = $.trim( venueLink.text() );
-    if( !venueName ) return;
-
-    venueLink.addClass( "mdb-ra-venue-copy-processed" );
-
-    var button = $("<button>")
-        .attr({
-            "aria-label": "Copy venue name",
-            title: "Copy venue name",
-            type: "button"
-        })
-        .addClass( "mdb-ra-venue-copy-button" )
-        .text( "⧉" );
-
-    button.on( "click", function( event ) {
-        event.preventDefault();
-        event.stopPropagation();
-
-        var currentVenueName = $.trim( venueLink.text() );
-        if( !currentVenueName ) return;
-
-        copyRaTextToClipboard( currentVenueName ).then(function() {
-            showRaCopyDialog( currentVenueName + " copied!" );
-        });
+    appendMdbCopyTextButton( venueLink, {
+        ariaLabel: "Copy venue name",
+        buttonTitle: "Copy venue name",
+        copiedMessage: function( text ) {
+            return text + " copied!";
+        },
+        sourceClass: "mdb-copy-text-source-ra-event-venue"
     });
-
-    venueLink.after( button );
 }
 
-waitForKeyElements("a[data-pw-test-id='event-venue-link']:not(.mdb-ra-venue-copy-processed)", function( jNode ) {
+waitForKeyElements("a[data-pw-test-id='event-venue-link']:not(.mdb-copy-text-processed)", function( jNode ) {
     appendRaVenueCopyButton( jNode );
 });
 

--- a/includes/global.css
+++ b/includes/global.css
@@ -184,6 +184,67 @@ button.mdb-element {
     font-size: .9rem;
 }
 
+.mdb-copy-text-source {
+    display: inline !important;
+    width: auto !important;
+}
+
+.mdb-copy-text-control {
+    align-items: center;
+    display: inline-flex;
+    flex-direction: column;
+    margin-left: 6px;
+    position: relative;
+    vertical-align: middle;
+}
+
+.mdb-copy-text-button {
+    align-items: center;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 3px;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    font: inherit;
+    height: 20px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0 5px;
+}
+
+.mdb-copy-text-button:hover,
+.mdb-copy-text-button:focus {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.7);
+}
+
+.mdb-copy-text-feedback {
+    background: rgba(0, 0, 0, 0.8);
+    border-radius: 3px;
+    color: #fff;
+    font-family: sans-serif;
+    font-size: 12px;
+    left: 50%;
+    line-height: 1.3;
+    margin-top: 3px;
+    opacity: 0;
+    padding: 2px 5px;
+    pointer-events: none;
+    position: absolute;
+    top: 100%;
+    transform: translateX(-50%);
+    transition: opacity .2s ease;
+    visibility: hidden;
+    white-space: nowrap;
+    z-index: 1000;
+}
+
+.mdb-copy-text-feedback.visible {
+    opacity: 1;
+    visibility: visible;
+}
+
 table.mdb-element {
     & th,
     & td {

--- a/includes/global.js
+++ b/includes/global.js
@@ -738,6 +738,117 @@ function create_button( text, className, type ) {
     return '<button type="'+type+'" class="mdb-element button '+ className +'">'+text+'</button>';
 }
 
+// mdbCopyTextToClipboard
+function mdbCopyTextToClipboard( text ) {
+    if( navigator.clipboard && navigator.clipboard.writeText ) {
+        return navigator.clipboard.writeText( text );
+    }
+
+    var textarea = $("<textarea>")
+        .val( text )
+        .attr( "readonly", true )
+        .css({
+            left: "-9999px",
+            position: "fixed",
+            top: "-9999px"
+        })
+        .appendTo( document.body );
+
+    textarea[0].select();
+    document.execCommand( "copy" );
+    textarea.remove();
+
+    return Promise.resolve();
+}
+
+// showMdbCopyTextFeedback
+function showMdbCopyTextFeedback( button, message ) {
+    var control = $(button).closest( ".mdb-copy-text-control" ),
+        feedback = control.find( ".mdb-copy-text-feedback" ).first();
+
+    if( !feedback.length ) {
+        feedback = $("<span>")
+            .addClass( "mdb-copy-text-feedback" )
+            .attr( "role", "status" )
+            .attr( "aria-live", "polite" )
+            .appendTo( control );
+    }
+
+    clearTimeout( feedback.data( "mdb-copy-text-timeout" ) );
+
+    feedback
+        .text( message )
+        .addClass( "visible" );
+
+    feedback.data( "mdb-copy-text-timeout", setTimeout(function() {
+        feedback.removeClass( "visible" ).text( "" );
+    }, 2200));
+}
+
+// appendMdbCopyTextButton
+function appendMdbCopyTextButton( source, options ) {
+    var settings = $.extend({
+            ariaLabel: "Copy text",
+            buttonTitle: "Copy text",
+            buttonText: "⧉",
+            copiedMessage: function( text ) {
+                return text + " copied!";
+            },
+            emptyMessage: "Nothing to copy.",
+            failedMessage: "Copy failed.",
+            processedClass: "mdb-copy-text-processed",
+            sourceClass: ""
+        }, options || {}),
+        sourceNode = $(source).first();
+
+    if( !sourceNode.length || sourceNode.hasClass( settings.processedClass ) ) return;
+
+    var sourceText = $.trim( sourceNode.text() );
+    if( !sourceText ) return;
+
+    sourceNode.addClass( settings.processedClass + " mdb-copy-text-source" );
+
+    if( settings.sourceClass ) {
+        sourceNode.addClass( settings.sourceClass );
+    }
+
+    var control = $("<span>")
+            .addClass( "mdb-copy-text-control" ),
+        button = $("<button>")
+            .attr({
+                "aria-label": settings.ariaLabel,
+                title: settings.buttonTitle,
+                type: "button"
+            })
+            .addClass( "mdb-copy-text-button" )
+            .text( settings.buttonText ),
+        feedback = $("<span>")
+            .addClass( "mdb-copy-text-feedback" )
+            .attr( "role", "status" )
+            .attr( "aria-live", "polite" );
+
+    button.on( "click", function( event ) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        var currentText = $.trim( sourceNode.text() );
+
+        if( !currentText ) {
+            showMdbCopyTextFeedback( button, settings.emptyMessage );
+            return;
+        }
+
+        mdbCopyTextToClipboard( currentText ).then(function() {
+            showMdbCopyTextFeedback( button, settings.copiedMessage( currentText ) );
+        }).catch(function() {
+            showMdbCopyTextFeedback( button, settings.failedMessage );
+        });
+    });
+
+    control.append( button, feedback );
+    sourceNode.after( control );
+}
+
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *


### PR DESCRIPTION
### Motivation
- Ensure the RA venue copy button sits inline next to the venue text instead of behaving like a block element.
- Replace the blocking `alert()` dialog with a non-interrupting inline status message that appears under the button and fades away.
- Make the copy-button logic reusable across userscripts by moving it into the global utilities instead of keeping an RA-specific implementation.
- Bump cache/version values so the updated shared assets are loaded by the RA userscript.

### Description
- Added reusable clipboard helpers to `includes/global.js`: `mdbCopyTextToClipboard`, `showMdbCopyTextFeedback`, and `appendMdbCopyTextButton` which insert an inline button and temporary feedback element.
- Updated `RA/script.user.js` to use `appendMdbCopyTextButton` for RA event venue links and removed the old RA-specific copy functions and `alert()` usage.
- Moved styling into `includes/global.css` using generic `.mdb-copy-text-*` classes and removed the former `.mdb-ra-venue-copy-button` rules from `RA/script.css` so the button aligns inline with the text.
- Bumped the RA userscript `@version` to `2026.06.08.4`, increased `cacheVersion` to load the new CSS/JS, and updated the required `includes/global.js` URL version.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it succeeded.
- Ran `node --check includes/global.js` to validate syntax of the new helper code and it succeeded.
- Ran `node --check RA/script.user.js` to validate the RA script syntax after integration and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b622a8548320a6e6487ee1abd5dd)