### PR TITLE
Fix RA venue copy button alignment

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -45,3 +45,19 @@
 .mdb-ra-tracklist-editor {
     margin-top: -10px;
 }
+
+.mdb-ra-event-venue-copy-row {
+    align-items: center;
+    display: inline-flex;
+    flex: 0 1 auto;
+    max-width: 100%;
+    width: fit-content;
+}
+
+.mdb-ra-event-venue-copy-row > .mdb-copy-text-source-ra-event-venue {
+    min-width: 0;
+}
+
+.mdb-ra-event-venue-copy-row > .mdb-copy-text-control {
+    flex: 0 0 auto;
+}

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.08.4
+// @version      2026.06.08.5
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 12,
+var cacheVersion = 13,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -77,6 +77,14 @@ function isRaArtworkPage() {
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+function groupRaVenueCopyButton( venueLink ) {
+    var control = venueLink.next( ".mdb-copy-text-control" );
+
+    if( !control.length || venueLink.parent().hasClass( "mdb-ra-event-venue-copy-row" ) ) return;
+
+    venueLink.add( control ).wrapAll( $( "<span>" ).addClass( "mdb-ra-event-venue-copy-row" ) );
+}
+
 function appendRaVenueCopyButton( venueLink ) {
     if( !isRaEventPage() ) return;
 
@@ -88,6 +96,8 @@ function appendRaVenueCopyButton( venueLink ) {
         },
         sourceClass: "mdb-copy-text-source-ra-event-venue"
     });
+
+    groupRaVenueCopyButton( venueLink );
 }
 
 waitForKeyElements("a[data-pw-test-id='event-venue-link']:not(.mdb-copy-text-processed)", function( jNode ) {


### PR DESCRIPTION
### Motivation
- The RA event venue copy button was being placed on a separate line because RA's wrapper uses `display: flex;`, causing the copy control to break out of the venue link flow. 
- The intent is to keep the venue name and the copy button visually grouped and inline so the button remains next to the venue name. 
- The userscript version and CSS cache key were bumped so the updated stylesheet is fetched for today's release.

### Description
- Added a new helper `groupRaVenueCopyButton(venueLink)` that wraps the venue link and its adjacent `.mdb-copy-text-control` in a single container with class `mdb-ra-event-venue-copy-row` using `wrapAll`.
- Updated `appendRaVenueCopyButton` to call `groupRaVenueCopyButton` after appending the copy control.
- Bumped the userscript `@version` to `2026.06.08.5` and incremented `cacheVersion` to `13` in `RA/script.user.js` so the changed CSS is reloaded.
- Added RA-specific CSS in `RA/script.css` for `.mdb-ra-event-venue-copy-row` to use `display: inline-flex;` and sizing rules so the venue and button remain on the same line.

### Testing
- Ran `node --check RA/script.user.js` to validate the script syntax and it completed successfully.
- Ran `git diff --check` to ensure no whitespace/errors in diffs and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ba1c33fc8320be5c81713867409f)