### PR TITLE
Add RA venue MixesDB search button

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -61,3 +61,21 @@
 .mdb-ra-event-venue-copy-row > .mdb-copy-text-control {
     flex: 0 0 auto;
 }
+
+.mdb-ra-event-venue-copy-row > .mdb-ra-event-venue-mixesdb-control {
+    background: #0645ad;
+    border-radius: 3px;
+    color: #fff !important;
+    flex: 0 0 auto;
+    font: inherit;
+    line-height: 22px;
+    margin-left: 6px;
+    padding: 0 6px;
+    text-decoration: none;
+}
+
+.mdb-ra-event-venue-copy-row > .mdb-ra-event-venue-mixesdb-control:hover,
+.mdb-ra-event-venue-copy-row > .mdb-ra-event-venue-mixesdb-control:focus {
+    background: #0b5ed7;
+    color: #fff !important;
+}

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.08.7
+// @version      2026.06.08.8
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 14,
+var cacheVersion = 15,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -77,12 +77,40 @@ function isRaArtworkPage() {
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+function getRaMixesDbSearchUrl( searchText ) {
+    return "https://www.mixesdb.com/w/index.php?title=Special:Search&search="
+        + encodeURIComponent( searchText )
+        + "&mode=simple&fulltext=1&profile=cats";
+}
+
+function appendRaVenueMixesDbButton( venueLink ) {
+    var sourceText = $.trim( venueLink.text() ),
+        control = venueLink.next( ".mdb-copy-text-control" );
+
+    if( !sourceText || !control.length || control.next( ".mdb-ra-event-venue-mixesdb-control" ).length ) return;
+
+    $( "<a>" )
+        .attr({
+            "aria-label": "Search venue on MixesDB",
+            href: getRaMixesDbSearchUrl( sourceText ),
+            rel: "noopener noreferrer",
+            target: "_blank",
+            title: "Search venue on MixesDB"
+        })
+        .addClass( "mdb-ra-event-venue-mixesdb-control" )
+        .text( "MixesDB" )
+        .insertAfter( control );
+}
+
 function groupRaVenueCopyButton( venueLink ) {
-    var control = venueLink.next( ".mdb-copy-text-control" );
+    var control = venueLink.next( ".mdb-copy-text-control" ),
+        mixesDbControl = control.next( ".mdb-ra-event-venue-mixesdb-control" );
 
     if( !control.length || venueLink.parent().hasClass( "mdb-ra-event-venue-copy-row" ) ) return;
 
-    venueLink.add( control ).wrapAll( $( "<span>" ).addClass( "mdb-ra-event-venue-copy-row" ) );
+    venueLink.add( control )
+        .add( mixesDbControl )
+        .wrapAll( $( "<span>" ).addClass( "mdb-ra-event-venue-copy-row" ) );
 }
 
 function appendRaVenueCopyButton( venueLink ) {
@@ -97,6 +125,7 @@ function appendRaVenueCopyButton( venueLink ) {
         sourceClass: "mdb-copy-text-source-ra-event-venue"
     });
 
+    appendRaVenueMixesDbButton( venueLink );
     groupRaVenueCopyButton( venueLink );
 }
 


### PR DESCRIPTION
### Motivation
- Provide a quick MixesDB full-text search for RA event venues using the venue/club name.
- Integrate the MixesDB action into the existing inline venue controls so it aligns with the copy button.
- Bump userscript and CSS cache versions so the change is picked up by users and styles are reloaded.

### Description
- Added `getRaMixesDbSearchUrl(searchText)` to build the MixesDB search URL with proper encoding and search parameters.
- Added `appendRaVenueMixesDbButton(venueLink)` to insert a `MixesDB` link element after the existing copy control and open it in a new tab.
- Updated `groupRaVenueCopyButton` to include the new `.mdb-ra-event-venue-mixesdb-control` when wrapping controls into `.mdb-ra-event-venue-copy-row`.
- Added CSS rules in `RA/script.css` for `.mdb-ra-event-venue-mixesdb-control` to style the new button, and bumped `cacheVersion` and the userscript `@version` in `RA/script.user.js`.

### Testing
- Ran `node --check RA/script.user.js` which completed without errors.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26cd37c4888320a993f521e39c0b0c)