### PR TITLE
RA: Use MixesDB icon and add copy/search controls for venue & artist

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -46,7 +46,8 @@
     margin-top: -10px;
 }
 
-.mdb-ra-event-venue-copy-row {
+.mdb-ra-event-venue-copy-row,
+.mdb-ra-profile-name-copy-row {
     align-items: center;
     display: inline-flex;
     flex: 0 1 auto;
@@ -54,28 +55,39 @@
     width: fit-content;
 }
 
-.mdb-ra-event-venue-copy-row > .mdb-copy-text-source-ra-event-venue {
+.mdb-ra-event-venue-copy-row > .mdb-copy-text-source-ra-event-venue,
+.mdb-ra-profile-name-copy-row > .mdb-copy-text-source-ra-profile-name {
     min-width: 0;
 }
 
-.mdb-ra-event-venue-copy-row > .mdb-copy-text-control {
+.mdb-ra-event-venue-copy-row > .mdb-copy-text-control,
+.mdb-ra-profile-name-copy-row > .mdb-copy-text-control,
+.mdb-ra-event-venue-copy-row > .mdb-ra-mixesdb-control,
+.mdb-ra-profile-name-copy-row > .mdb-ra-mixesdb-control {
     flex: 0 0 auto;
 }
 
-.mdb-ra-event-venue-copy-row > .mdb-ra-event-venue-mixesdb-control {
-    background: #0645ad;
-    border-radius: 3px;
-    color: #fff !important;
-    flex: 0 0 auto;
-    font: inherit;
-    line-height: 22px;
+.mdb-ra-mixesdb-control {
+    align-items: center;
+    display: inline-flex;
+    height: 22px;
+    justify-content: center;
     margin-left: 6px;
-    padding: 0 6px;
+    opacity: .85;
     text-decoration: none;
+    transition: opacity .15s ease, transform .15s ease;
+    vertical-align: middle;
+    width: 22px;
 }
 
-.mdb-ra-event-venue-copy-row > .mdb-ra-event-venue-mixesdb-control:hover,
-.mdb-ra-event-venue-copy-row > .mdb-ra-event-venue-mixesdb-control:focus {
-    background: #0b5ed7;
-    color: #fff !important;
+.mdb-ra-mixesdb-control:hover,
+.mdb-ra-mixesdb-control:focus {
+    opacity: 1;
+    transform: scale(1.08);
+}
+
+.mdb-ra-mixesdb-control img {
+    display: block;
+    height: 22px;
+    width: 22px;
 }

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.08.9
+// @version      2026.06.08.10
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 15,
+var cacheVersion = 16,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -73,7 +73,7 @@ function isRaArtworkPage() {
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *
- * Event venue copy button
+ * Copy buttons and MixesDB search links
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -83,54 +83,119 @@ function getRaMixesDbSearchUrl( searchText ) {
         + "&mode=simple&fulltext=1&profile=cats";
 }
 
-function appendRaVenueMixesDbButton( venueLink ) {
-    var sourceText = $.trim( venueLink.text() ),
-        control = venueLink.next( ".mdb-copy-text-control" );
+function getRaMixesDbIconUrl( width ) {
+    return "https://www.mixesdb.com/w/thumb.php?f=MixesDB_logo_-_no_padding.png&width=" + width;
+}
 
-    if( !sourceText || !control.length || control.next( ".mdb-ra-event-venue-mixesdb-control" ).length ) return;
+function isRaVenuePage() {
+    return /^\/clubs\/\d+(?:[/?#]|$)/.test( window.location.pathname );
+}
+
+function isRaArtistPage() {
+    return /^\/dj\/[^/?#]+(?:[/?#]|$)/.test( window.location.pathname );
+}
+
+function appendRaMixesDbButton( sourceNode, options ) {
+    var settings = $.extend({
+            buttonClass: "mdb-ra-mixesdb-control",
+            iconWidth: 44,
+            insertAfter: null,
+            label: "Search on MixesDB"
+        }, options || {}),
+        sourceText = $.trim( sourceNode.text() ),
+        insertAfter = settings.insertAfter ? $(settings.insertAfter) : sourceNode;
+
+    if( !sourceText || !insertAfter.length || insertAfter.next( "." + settings.buttonClass ).length ) return;
 
     $( "<a>" )
         .attr({
-            "aria-label": "Search venue on MixesDB",
+            "aria-label": settings.label,
             href: getRaMixesDbSearchUrl( sourceText ),
             rel: "noopener noreferrer",
             target: "_blank",
-            title: "Search venue on MixesDB"
+            title: settings.label
         })
-        .addClass( "mdb-ra-event-venue-mixesdb-control" )
-        .text( "MixesDB" )
-        .insertAfter( control );
+        .addClass( settings.buttonClass )
+        .append( $( "<img>" ).attr({
+            alt: "",
+            height: 22,
+            src: getRaMixesDbIconUrl( settings.iconWidth ),
+            width: 22
+        }))
+        .insertAfter( insertAfter );
 }
 
-function groupRaVenueCopyButton( venueLink ) {
-    var control = venueLink.next( ".mdb-copy-text-control" ),
-        mixesDbControl = control.next( ".mdb-ra-event-venue-mixesdb-control" );
+function groupRaInlineControls( sourceNode, options ) {
+    var settings = $.extend({
+            rowClass: "mdb-ra-copy-row",
+            mixesDbClass: "mdb-ra-mixesdb-control"
+        }, options || {}),
+        control = sourceNode.next( ".mdb-copy-text-control" ),
+        mixesDbControl = control.next( "." + settings.mixesDbClass );
 
-    if( !control.length || venueLink.parent().hasClass( "mdb-ra-event-venue-copy-row" ) ) return;
+    if( !control.length || sourceNode.parent().hasClass( settings.rowClass ) ) return;
 
-    venueLink.add( control )
+    sourceNode.add( control )
         .add( mixesDbControl )
-        .wrapAll( $( "<span>" ).addClass( "mdb-ra-event-venue-copy-row" ) );
+        .wrapAll( $( "<span>" ).addClass( settings.rowClass ) );
 }
 
-function appendRaVenueCopyButton( venueLink ) {
-    if( !isRaEventPage() ) return;
-
-    appendMdbCopyTextButton( venueLink, {
-        ariaLabel: "Copy the name",
-        buttonTitle: "Copy the name",
+function appendRaInlineCopyAndMixesDbButtons( sourceNode, options ) {
+    var settings = $.extend({
         copiedMessage: function( text ) {
             return "'"+ text + "' copied!";
         },
-        sourceClass: "mdb-copy-text-source-ra-event-venue"
+        mixesDbLabel: "Search on MixesDB",
+        rowClass: "mdb-ra-copy-row",
+        sourceClass: ""
+    }, options || {});
+
+    appendMdbCopyTextButton( sourceNode, {
+        ariaLabel: "Copy the name",
+        buttonTitle: "Copy the name",
+        copiedMessage: settings.copiedMessage,
+        sourceClass: settings.sourceClass
     });
 
-    appendRaVenueMixesDbButton( venueLink );
-    groupRaVenueCopyButton( venueLink );
+    appendRaMixesDbButton( sourceNode, {
+        insertAfter: sourceNode.next( ".mdb-copy-text-control" ),
+        label: settings.mixesDbLabel
+    });
+
+    groupRaInlineControls( sourceNode, {
+        rowClass: settings.rowClass
+    });
+}
+
+function appendRaEventVenueCopyButton( venueLink ) {
+    if( !isRaEventPage() ) return;
+
+    appendRaInlineCopyAndMixesDbButtons( venueLink, {
+        mixesDbLabel: "Search venue on MixesDB",
+        rowClass: "mdb-ra-event-venue-copy-row",
+        sourceClass: "mdb-copy-text-source-ra-event-venue"
+    });
+}
+
+function appendRaProfileNameCopyButton( profileName ) {
+    var isVenue = isRaVenuePage(),
+        isArtist = isRaArtistPage();
+
+    if( !isVenue && !isArtist ) return;
+
+    appendRaInlineCopyAndMixesDbButtons( profileName, {
+        mixesDbLabel: isVenue ? "Search venue on MixesDB" : "Search artist on MixesDB",
+        rowClass: "mdb-ra-profile-name-copy-row",
+        sourceClass: "mdb-copy-text-source-ra-profile-name"
+    });
 }
 
 waitForKeyElements("a[data-pw-test-id='event-venue-link']:not(.mdb-copy-text-processed)", function( jNode ) {
-    appendRaVenueCopyButton( jNode );
+    appendRaEventVenueCopyButton( jNode );
+});
+
+waitForKeyElements("[class*='ProfileHeader__HeaderContentWrapper'] h1 span:not(.mdb-copy-text-processed)", function( jNode ) {
+    appendRaProfileNameCopyButton( jNode );
 });
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *


### PR DESCRIPTION
### Motivation
- Replace the current MixesDB text/color link with a compact icon to match the requested MixesDB thumbnail UX.
- Provide a consistent copy + search control for event venue names and profile pages (venues and artists). 
- Ensure the userscript and CSS cache versions are bumped for a release with today's date.

### Description
- Replaced the MixesDB text pill with an icon-based link that uses the MixesDB thumbnail URL (`https://www.mixesdb.com/w/thumb.php?f=MixesDB_logo_-_no_padding.png&width=`) and added `getRaMixesDbIconUrl` to generate the image URL. 
- Refactored copy/search helpers into reusable functions: `appendRaMixesDbButton`, `appendRaInlineCopyAndMixesDbButtons`, `groupRaInlineControls`, plus page-detection helpers `isRaVenuePage` and `isRaArtistPage`, and wired them to event venue links and profile name headings. 
- Updated CSS to show a compact 22×22 icon (`.mdb-ra-mixesdb-control`) and to support shared inline layout for venue and profile name control rows. 
- Bumped userscript header version and `cacheVersion` for the RA script (`RA/script.user.js`) and updated `RA/script.css` accordingly.

### Testing
- Ran `node --check RA/script.user.js` to validate the script syntax and it succeeded. 
- Ran `git diff --check` (whitespace/checks) and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d39b23548320822b83e27f6bd00a)