### PR TITLE
Enlarge RA profile name controls to 44px

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -91,3 +91,14 @@
     height: 22px;
     width: 22px;
 }
+
+.mdb-ra-profile-name-copy-row > .mdb-copy-text-control .mdb-copy-text-button {
+    min-height: 44px;
+    min-width: 44px;
+}
+
+.mdb-ra-profile-name-copy-row > .mdb-ra-mixesdb-control,
+.mdb-ra-profile-name-copy-row > .mdb-ra-mixesdb-control img {
+    height: 44px;
+    width: 44px;
+}

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.06.08.11
+// @version      2026.06.08.12
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 16,
+var cacheVersion = 17,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );


### PR DESCRIPTION
### Motivation
- The profile name row copy button and MixesDB icon on RA were too small for the requested target size, so they should be enlarged from 22px to 44px for better usability.

### Description
- Add CSS rules in `RA/script.css` to set the profile-name-row copy button minimum size to 44px and to size the MixesDB control and its icon to 44px while leaving other controls at 22px.
- Bump `cacheVersion` from `16` to `17` in `RA/script.user.js` and update the userscript `@version` suffix to `2026.06.08.12` so the change will be picked up.

### Testing
- Ran `git diff --check` to validate the diff and whitespace issues, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26ea9f75488320859053a9265b2d50)