### PR TITLE
Fix Resident tracklist extraction and preserve linebreaks

### DIFF
--- a/Hernan_Cattaneo_Resident/script.user.js
+++ b/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.02.3
+// @version      2026.07.02.4
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -101,15 +101,31 @@
             .trim();
     }
 
+    function getNodeTextWithLinebreaks(node) {
+        return Array.from(node.childNodes)
+            .map(child => {
+                if (child.nodeName === 'BR') return '\n';
+                if (child.nodeType === Node.TEXT_NODE) return child.textContent;
+                return getNodeTextWithLinebreaks(child);
+            })
+            .join('');
+    }
+
     function extractRawTracklist(wrapper) {
-        const description = wrapper.querySelector('.episode-description');
+        const description = wrapper.querySelector('p.e-description, .episode-description');
         if (!description) return '';
 
-        const firstParagraph = description.querySelector('p');
+        const browserParsedFirstParagraph = description.matches('p.e-description')
+            && !getNodeTextWithLinebreaks(description).trim()
+            && description.nextElementSibling
+            && description.nextElementSibling.matches('p')
+            ? description.nextElementSibling
+            : null;
+        const firstParagraph = description.matches('p.e-description')
+            ? browserParsedFirstParagraph || description.querySelector('p')
+            : description.querySelector('p');
         const source = firstParagraph || description;
-        return Array.from(source.childNodes)
-            .map(node => node.nodeName === 'BR' ? '\n' : node.textContent)
-            .join('')
+        return getNodeTextWithLinebreaks(source)
             .split('\n')
             .map(normalizeTracklistLine)
             .filter(Boolean)
@@ -118,6 +134,8 @@
 
     async function formatTracklist(rawTracklist) {
         if (!rawTracklist) return '';
+
+        console.log('Hernan Cattaneo Resident tracklist before Tracklist Editor API:', rawTracklist);
 
         const body = new URLSearchParams({
             query: 'tracklistEditor',
@@ -136,7 +154,9 @@
         }
 
         const data = await response.json();
-        return data.text || rawTracklist.split('\n').map(line => `# ${line}`).join('\n');
+        const formattedTracklist = data.text || rawTracklist.split('\n').map(line => `# ${line}`).join('\n');
+        console.log('Hernan Cattaneo Resident tracklist after Tracklist Editor API:', formattedTracklist);
+        return formattedTracklist;
     }
 
     function buildMixPageText(episode, tracklist) {


### PR DESCRIPTION
### Motivation
- The site uses `p.e-description` where the actual tracklist is the first paragraph, and malformed nested `<p>` markup can cause the browser to parse the real lines into a sibling paragraph.  
- Tracklist linebreaks produced by `<br>` must be preserved so the Tracklist Editor API receives the correct input.  
- Add logging to inspect the raw and API-formatted tracklist for easier debugging when formatting fails.

### Description
- Bumped the userscript version to `2026.07.02.4` in `Hernan_Cattaneo_Resident/script.user.js` to reflect the update.  
- Added `getNodeTextWithLinebreaks(node)` to recursively extract text while converting `<br>` elements to `\n`.  
- Updated `extractRawTracklist(wrapper)` to select `p.e-description` first, use only the first associated paragraph, and fall back to the browser-parsed sibling paragraph when `p` was incorrectly nested.  
- Added console logging in `formatTracklist` to print the tracklist before and after the Tracklist Editor API call and preserved the API fallback formatting logic.

### Testing
- Ran `node --check Hernan_Cattaneo_Resident/script.user.js` and it succeeded.  
- Ran `git diff --check` and no whitespace or diff-check errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4641183bcc832096414347b0fba46a)