### PR TITLE
Validate Resident episode mp3 URLs

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.02.11
+// @version      2026.07.06.01
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -95,9 +95,24 @@
             .join('\n');
     }
 
+    function isValidPlayerUrl(playerUrl) {
+        if (!playerUrl) return false;
+
+        try {
+            const url = new URL(playerUrl, location.href);
+            const host = url.hostname.toLowerCase();
+            return ['http:', 'https:'].includes(url.protocol)
+                && url.pathname.toLowerCase().endsWith('.mp3')
+                && host !== 'url-del-episodio.mp3';
+        } catch (error) {
+            return false;
+        }
+    }
+
     function extractPlayerUrl(wrapper) {
         const player = wrapper.querySelector(config.selectors.player);
-        return player ? (player.href || player.src || '') : '';
+        const playerUrl = player ? (player.href || player.src || '') : '';
+        return isValidPlayerUrl(playerUrl) ? new URL(playerUrl, location.href).toString() : '';
     }
 
     function buildEpisodePageText(episode, tracklistResult, playerUrl = '') {


### PR DESCRIPTION
### Motivation
- Avoid including placeholder or invalid MP3 links (e.g. `https://url-del-episodio.mp3`) in generated MixesDB page text by only adding real HTTP/HTTPS `.mp3` URLs.

### Description
- Bumped the Hernan Cattaneo Resident userscript version to `2026.07.06.01` and added an `isValidPlayerUrl` helper that checks protocol, `.mp3` pathname, and excludes placeholder hosts, then updated `extractPlayerUrl` to return a validated absolute MP3 URL or an empty string in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` which succeeded. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b5dae0878832099e9ac98e60e30f2)