### PR TITLE
Add Resident TLE API feedback

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.06.01
+// @version      2026.07.06.02
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.02
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.06.02
 // @include      https://podcast.hernancattaneo.com*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hernancattaneo.com
@@ -45,6 +45,7 @@
             closeButton: 'mdb-resident-close-button',
             toggle: 'mdb-resident-remove-existing-toggle',
             hidden: 'mdb-resident-existing-episode-hidden',
+            apiFeedback: 'mdb-resident-tle-feedback',
         },
     };
 
@@ -83,11 +84,47 @@
             : null;
     }
 
+
+    function getTracklistSourceNode(wrapper) {
+        const description = wrapper.querySelector(config.selectors.description);
+        if (!description) return null;
+        return getFirstDescriptionParagraph(description) || description;
+    }
+
+    function getTleFeedbackClass(feedback) {
+        if (!feedback) return '';
+        if (feedback.warnings > 0) return 'tlEditor-feedback-warning';
+        if (feedback.hints > 0 || feedback.status === 'incomplete') return 'tlEditor-feedback-hint';
+        return 'tlEditor-feedback-complete';
+    }
+
+    function renderTracklistApiFeedback(wrapper, tracklistResult) {
+        const source = getTracklistSourceNode(wrapper);
+        if (!source) return;
+
+        let feedback = wrapper.querySelector(`.${config.classNames.apiFeedback}`);
+        if (!tracklistResult.feedback || !tracklistResult.feedback.text) {
+            feedback?.remove();
+            return;
+        }
+
+        if (!feedback) {
+            feedback = document.createElement('div');
+            feedback.className = config.classNames.apiFeedback;
+            source.insertAdjacentElement('afterend', feedback);
+        }
+
+        feedback.className = [config.classNames.apiFeedback, getTleFeedbackClass(tracklistResult.feedback)]
+            .filter(Boolean)
+            .join(' ');
+        feedback.innerHTML = tracklistResult.feedback.text;
+    }
+
     function extractRawTracklist(wrapper) {
         const description = wrapper.querySelector(config.selectors.description);
         if (!description) return '';
 
-        const source = getFirstDescriptionParagraph(description) || description;
+        const source = getTracklistSourceNode(wrapper);
         return importer.getNodeTextWithLinebreaks(source)
             .split('\n')
             .map(importer.normalizeTracklistLine)
@@ -150,6 +187,7 @@
         const rawTracklist = extractRawTracklist(wrapper);
         try {
             const tracklist = await importer.formatTracklist(rawTracklist);
+            renderTracklistApiFeedback(wrapper, tracklist);
             link.href = importer.buildMixesdbUrl(title, episodeUrl, buildEpisodePageText(episode, tracklist, extractPlayerUrl(wrapper)));
         } catch (error) {
             importer.logValue('Failed to format Resident tracklist for MixesDB', error.message || error);
@@ -157,6 +195,7 @@
                 ? rawTracklist.split('\n').filter(Boolean).map(line => `# ${line}`).join('\n')
                 : '<list>\n\n</list>';
             const fallbackStatus = importer.hasTracklistForApi(rawTracklist) ? 'incomplete' : 'none';
+            renderTracklistApiFeedback(wrapper, { feedback: null });
             link.href = importer.buildMixesdbUrl(title, episodeUrl, buildEpisodePageText(episode, { text: fallbackTracklist, status: fallbackStatus }, extractPlayerUrl(wrapper)));
         }
         link.className = `${config.classNames.link} is-missing`;
@@ -301,6 +340,34 @@
                 background: #ff660050;
                 border: 1px solid #f60;
                 color: #ffffff !important;
+            }
+
+            .${config.classNames.apiFeedback} {
+                margin: 0.6rem 0 1rem;
+            }
+            .${config.classNames.apiFeedback} #tlEditor-feedback {
+                border-style: solid;
+                border-width: 1px;
+                padding: 0.65em 0.6em 0.5em;
+            }
+            .${config.classNames.apiFeedback}.tlEditor-feedback-complete #tlEditor-feedback {
+                background: #efd;
+                border-color: #090 !important;
+                color: #090;
+            }
+            .${config.classNames.apiFeedback}.tlEditor-feedback-hint #tlEditor-feedback {
+                background: #fffddf;
+                border-color: rgb(255, 170, 0) !important;
+                color: rgb(255, 170, 0);
+            }
+            .${config.classNames.apiFeedback}.tlEditor-feedback-warning #tlEditor-feedback {
+                background: #fee;
+                border-color: rgb(255, 0, 0) !important;
+                color: rgb(255, 0, 0);
+            }
+            .${config.classNames.apiFeedback} #tlEditor-feedback ul {
+                margin-bottom: 0;
+                margin-top: 0;
             }
             /* Hide donation banner block */
             .e-description table {

--- a/Episodes_Importer/funcs.js
+++ b/Episodes_Importer/funcs.js
@@ -97,7 +97,7 @@
 
     async function formatTracklist(rawTracklist) {
         if (!rawTracklist || !hasTracklistForApi(rawTracklist)) {
-            return { text: '<list>\n\n</list>', status: 'none' };
+            return { text: '<list>\n\n</list>', status: 'none', feedback: null };
         }
 
         logMessage('Tracklist before Tracklist Editor API:\n' + rawTracklist);
@@ -121,7 +121,7 @@
         const data = await response.json();
         const formattedTracklist = data.text || rawTracklist.split('\n').map(line => `# ${line}`).join('\n');
         logMessage('Tracklist after Tracklist Editor API:\n' + formattedTracklist);
-        return { text: formattedTracklist, status: getFeedbackTracklistStatus(data.feedback) };
+        return { text: formattedTracklist, status: getFeedbackTracklistStatus(data.feedback), feedback: data.feedback || null };
     }
 
     function buildPlayerText(playerUrl) {


### PR DESCRIPTION
### Motivation

- Show Tracklist Editor (TLE) API feedback under each displayed Resident tracklist so users can see parsing hints, warnings, or completion status inline.
- Surface the raw `feedback` object from the shared episode formatter so site-specific importers can render the API response.
- Keep the userscript cache key and version in-sync with today’s date-based bump.

### Description

- Bumped the Hernan Cattaneo Resident userscript version to `2026.07.06.02` and updated the `@require` cache key for `Episodes_Importer/funcs.js` to `v-2026.07.06.02`.
- Extended `formatTracklist` to return a `feedback` property (`feedback: data.feedback || null`) and return `feedback: null` for non-API fallbacks.
- Added Resident-specific functions `getTracklistSourceNode`, `getTleFeedbackClass`, and `renderTracklistApiFeedback` and wired `renderTracklistApiFeedback` into the `updateMixesdbLink` flow to render or clear TLE feedback after formatting.
- Added CSS rules for the new feedback block (status classes `tlEditor-feedback-complete`, `tlEditor-feedback-hint`, `tlEditor-feedback-warning`) and added a `classNames.apiFeedback` key for placement.

### Testing

- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it succeeded.
- Ran `node --check Episodes_Importer/funcs.js` and it succeeded.
- Ran `git diff --check` to validate whitespace / diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b63ed5e98832098c85a3c40238fde)