### PR TITLE
Move Resident "Copy to MixesDB" button below TLE feedback

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.06.04
+// @version      2026.07.06.05
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -25,7 +25,7 @@
  * global.js URL needs to be changed manually
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-var cacheVersion = 6,
+var cacheVersion = 7,
     scriptName = "hearthis.at";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -182,6 +182,24 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.textContent = `Checking episode ${importer.padNumber(episode.episodeNumber)}`;
     }
 
+    function getDownloadLink(wrapper) {
+        return wrapper.querySelector('a[href*=".mp3"]');
+    }
+
+    function placeCopyLink(link, wrapper) {
+        const apiFeedback = wrapper.querySelector(`.${config.classNames.apiFeedback}`);
+        const downloadLink = getDownloadLink(wrapper);
+
+        if (apiFeedback) {
+            apiFeedback.insertAdjacentElement('afterend', link);
+            return;
+        }
+
+        if (downloadLink) {
+            downloadLink.insertAdjacentElement('beforebegin', link);
+        }
+    }
+
     async function updateMixesdbLink(link, episode, wrapper) {
         const isExisting = existingEpisodes.has(episode.episodeNumber);
         const title = buildMixesdbTitle(episode);
@@ -213,6 +231,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         }
         link.className = `${config.classNames.link} is-missing`;
         link.textContent = 'Copy to MixesDB';
+        placeCopyLink(link, wrapper);
     }
 
     function setEpisodeVisibility(wrapper, episode) {


### PR DESCRIPTION
### Motivation
- Keep the existing "See on MixesDB" link in its current heading position while moving the actionable "Copy to MixesDB" button to a more logical place near the TLE API feedback or the download link. 
- Ensure the userscript and its resources are versioned so updates propagate to users by bumping the script and cache versions. 

### Description
- Bumped the userscript version to `2026.07.06.05` and incremented `cacheVersion` to `7` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Added `getDownloadLink` and `placeCopyLink` helper functions and call `placeCopyLink` from `updateMixesdbLink` so missing-episode "Copy to MixesDB" links are inserted after the TLE API feedback block or, if absent, immediately before the MP3 download link.
- Preserved behavior for existing episodes so the "See on MixesDB" link remains in-place and unchanged.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b6f1d72bc8320b818b0da6583bb3f)