### PR TITLE
Remove empty <p> tags from Hernan Cattaneo Resident episode wrappers

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.06.05
+// @version      2026.07.06.06
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -396,8 +396,19 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         document.head.appendChild(style);
     }
 
+    function removeEmptyEpisodeParagraphs(wrapper) {
+        wrapper.querySelectorAll('p').forEach(paragraph => {
+            const text = paragraph.textContent.replace(/\u00a0/g, ' ').trim();
+            if (!text && !paragraph.querySelector('img, audio, video, iframe, embed, object, input, textarea, select, button, a[href]')) {
+                paragraph.remove();
+            }
+        });
+    }
+
     function addEpisodeLinks() {
         document.querySelectorAll(config.selectors.episodeWrapper).forEach(wrapper => {
+            removeEmptyEpisodeParagraphs(wrapper);
+
             const heading = wrapper.querySelector(config.selectors.episodeHeading);
             if (!heading || heading.dataset.mdbImporterProcessed === 'true') return;
 


### PR DESCRIPTION
### Motivation
- Episode entries on the Hernan Cattaneo Resident page include empty paragraph tags such as `<p>&nbsp;</p>` which interfere with tracklist extraction and link placement. 
- Cleanup should run before processing each episode wrapper so downstream formatting/tracklist logic sees meaningful content only.

### Description
- Bumped the userscript version to `2026.07.06.06` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Added `removeEmptyEpisodeParagraphs(wrapper)` which removes empty `<p>` nodes (including those containing only `&nbsp;`) but preserves paragraphs that contain images, media, form controls, or links. 
- The cleanup is invoked at the start of `addEpisodeLinks()` so wrappers are sanitized before building MixesDB links.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b73845258832089951c31ab15ce01)