### PR TITLE
Fix Resident link visited opacity

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.06.06
+// @version      2026.07.06.07
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -45,6 +45,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         showCategory: 'Resident (Show)',
         genres: ['Progressive House'],
         storageKey: 'mdbResidentRemoveExistingEpisodes',
+        visitedLinksStorageKey: 'mdbResidentVisitedEpisodeLinks',
         selectors: {
             listContainer: '.container.list-container',
             episodeWrapper: '.container.list-container .list',
@@ -63,7 +64,30 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     };
 
     let existingEpisodes = new Set();
+    let visitedEpisodeLinks = new Set();
     let removeExistingEpisodes = false;
+
+    function loadVisitedEpisodeLinks() {
+        try {
+            visitedEpisodeLinks = new Set(JSON.parse(localStorage.getItem(config.visitedLinksStorageKey) || '[]'));
+        } catch (error) {
+            visitedEpisodeLinks = new Set();
+        }
+    }
+
+    function saveVisitedEpisodeLinks() {
+        localStorage.setItem(config.visitedLinksStorageKey, JSON.stringify(Array.from(visitedEpisodeLinks)));
+    }
+
+    function setLinkVisitedState(link) {
+        link.classList.toggle('is-visited', visitedEpisodeLinks.has(link.dataset.episodeNumber));
+    }
+
+    function markLinkVisited(link) {
+        visitedEpisodeLinks.add(link.dataset.episodeNumber);
+        saveVisitedEpisodeLinks();
+        setLinkVisitedState(link);
+    }
 
     function parseEpisodeTitle(title) {
         const match = title.match(/Resident\s*\/\s*Episode\s*(\d+)\s*\/\s*([A-Za-z]+)\s+(\d{1,2})\s+(\d{4})/i);
@@ -207,6 +231,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
 
         link.className = `${config.classNames.link} ${isExisting ? 'is-existing' : 'is-missing'}`;
         link.title = title;
+        setLinkVisitedState(link);
 
         if (isExisting) {
             link.href = importer.buildMixesdbUrl(title, episodeUrl);
@@ -232,6 +257,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.className = `${config.classNames.link} is-missing`;
         link.textContent = 'Copy to MixesDB';
         placeCopyLink(link, wrapper);
+        setLinkVisitedState(link);
     }
 
     function setEpisodeVisibility(wrapper, episode) {
@@ -276,6 +302,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.rel = 'noopener noreferrer';
         link.dataset.episodeNumber = String(episode.episodeNumber);
         link.dataset.episodeUrl = episodeLink ? episodeLink.href : location.href;
+        link.addEventListener('click', () => markLinkVisited(link));
         updateMixesdbLink(link, episode, wrapper);
 
         return link;
@@ -342,6 +369,9 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
                 font-weight: 700;
                 line-height: 1.4;
                 text-decoration: none;
+            }
+            .${config.classNames.link}.is-visited {
+                opacity: .62 !important;
             }
             .${config.classNames.link}.is-existing {
                 background: #2ea70060;
@@ -440,6 +470,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     if (location.hostname !== sourceHost) return;
 
     removeExistingEpisodes = localStorage.getItem(config.storageKey) === 'true';
+    loadVisitedEpisodeLinks();
     addStyles();
     addRemoveExistingToggle();
     importer.fetchExistingEpisodes(config)


### PR DESCRIPTION
### Motivation
- Browsers intentionally restrict what can be styled with `:visited`, so the requested `opacity` rule on `:${'visited'}` was not taking effect; the change implements an explicit visited state that's safe to style. 
- Persist clicked-link state across page loads and reapply it when links are created or updated so users can visually identify visited episode links.

### Description
- Bump userscript header `@version` to `2026.07.06.07` and add a new `config.visitedLinksStorageKey` (`mdbResidentVisitedEpisodeLinks`).
- Add `loadVisitedEpisodeLinks`, `saveVisitedEpisodeLinks`, `setLinkVisitedState`, and `markLinkVisited` to manage a `visitedEpisodeLinks` set persisted to `localStorage` and to toggle an `.is-visited` class on links.
- Wire links to call `markLinkVisited` on click and call `setLinkVisitedState` when links are created/updated so the visited state is reapplied after link updates.
- Replace the `:visited`-based styling with a normal rule `.${config.classNames.link}.is-visited { opacity: .62 !important; }` that can be applied reliably by the script.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba7ea231483209409a6845b0d183a)