### PR TITLE
Fix Resident importer dependency lookup

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.06.07
+// @version      2026.07.06.08
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.06.03
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.06.04
 // @include      https://podcast.hernancattaneo.com*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hernancattaneo.com
@@ -26,16 +26,20 @@
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 var cacheVersion = 7,
-    scriptName = "hearthis.at";
+    scriptName = "Hernan_Cattaneo_Resident";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
 
 
-/* global MixesDBEpisodesImporter, fixTLbox */
+/* global fixTLbox */
 (function () {
     'use strict';
 
-    const importer = MixesDBEpisodesImporter;
+    const importer = window.MixesDBEpisodesImporter;
+    if (!importer) {
+        console.error('MixesDBEpisodesImporter dependency is not available.');
+        return;
+    }
     const sourceHost = 'podcast.hernancattaneo.com';
     const mixesdbHost = 'www.mixesdb.com';
     const config = {


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError` when the shared Episodes Importer helper is not injected into the userscript global scope. 
- Ensure the userscript uses the correct CSS cache name and `@require` cache key so updated assets are loaded. 
- Bump the userscript version to reflect today's build as required for userscript releases.

### Description
- Bumped the userscript `// @version` and the `@require` helper cache key for `Episodes_Importer/funcs.js` to a new value. 
- Changed `scriptName` from `"hearthis.at"` to `"Hernan_Cattaneo_Resident"` so the CSS cache key is correct. 
- Replace the unqualified global `MixesDBEpisodesImporter` reference with `window.MixesDBEpisodesImporter` and add a safe early exit with `console.error` when the helper is missing to avoid an uncaught `ReferenceError`. 
- Updated the file header global annotation to remove the now-undefined global reference.

### Testing
- Ran `git diff --check` and it completed successfully. 
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bacefc3cc8320b83f0f89ce6b69f2)