### PR TITLE
Define Resident tracklist API type

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.06.10
+// @version      2026.07.06.11
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.06.9
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.06.10
 // @include      https://podcast.hernancattaneo.com*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hernancattaneo.com
@@ -50,6 +50,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         genres: ['Progressive House'],
         storageKey: 'mdbResidentRemoveExistingEpisodes',
         visitedLinksStorageKey: 'mdbResidentVisitedEpisodeLinks',
+        tleApiType: 'commaArtist',
         selectors: {
             listContainer: '.container.list-container',
             episodeWrapper: '.container.list-container .list',
@@ -246,7 +247,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         setLinkPending(link, episode);
         const rawTracklist = extractRawTracklist(wrapper);
         try {
-            const tracklist = await importer.formatTracklist(rawTracklist, 'thousandoneTl');
+            const tracklist = await importer.formatTracklist(rawTracklist, config.tleApiType);
             renderTracklistApiFeedback(wrapper, tracklist);
             link.href = importer.buildMixesdbUrl(title, episodeUrl, buildEpisodePageText(episode, tracklist, extractPlayerUrl(wrapper)));
         } catch (error) {


### PR DESCRIPTION
### Motivation
- Ensure the Hernan Cattaneo Resident userscript chooses the correct Tracklist Editor (TLE) API variant for formatting tracklists. 
- Keep the userscript and its `funcs.js` require URL cache-buster in sync and reflect today's version bump.

### Description
- Bump the userscript version to `2026.07.06.11` and update the `@require` URL for `Episodes_Importer/funcs.js` to the new cache-buster. 
- Add `tleApiType: 'commaArtist'` to the Resident userscript `config` so the TLE variant is defined inside the userscript. 
- Use the configured `config.tleApiType` when calling `formatTracklist` instead of the previous hardcoded `'thousandoneTl'`, while `formatTracklist` in `funcs.js` retains its default `apiType = 'standard'`.

### Testing
- `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` completed successfully. 
- `node --check Episodes_Importer/funcs.js` completed successfully. 
- `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bbb0302b083208017e1b765f7e6ae)