### PR TITLE
Ignore short Resident descriptions as tracklists

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.06.15
+// @version      2026.07.10.1
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.06.13
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.10.1
 // @include      https://podcast.hernancattaneo.com*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hernancattaneo.com
@@ -25,7 +25,7 @@
  * global.js URL needs to be changed manually
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-var cacheVersion = 9,
+var cacheVersion = 10,
     scriptName = "Hernan_Cattaneo_Resident";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );

--- a/Episodes_Importer/funcs.js
+++ b/Episodes_Importer/funcs.js
@@ -85,8 +85,8 @@
             .join('');
     }
 
-    function hasTracklistForApi(rawTracklist) {
-        return rawTracklist.split('\n').filter(Boolean).length > 1;
+    function hasTracklistForApi(rawTracklist, minimumLines = 4) {
+        return rawTracklist.split('\n').filter(Boolean).length >= minimumLines;
     }
 
     function getFeedbackTracklistStatus(feedback) {


### PR DESCRIPTION
### Motivation

- Short episode descriptions (1–3 non-empty lines) on the Hernan Cattaneo Resident site were being treated as tracklists and sent to the Tracklist Editor API, producing incorrect results. 
- The importer needs to treat only sufficiently long multi-line text as a tracklist to avoid false positives. 
- The Resident userscript needs a cache/version bump so the change is picked up by users.

### Description

- Change `hasTracklistForApi` in `Episodes_Importer/funcs.js` to accept a `minimumLines` parameter and treat text as a tracklist only when it contains at least 4 non-empty lines (`>= minimumLines`).
- Keep `formatTracklist` behavior but make it rely on the updated `hasTracklistForApi` check so short (1–3 line) descriptions return the empty `<list>` fallback.
- Bump the Hernan Cattaneo Resident userscript `@version`, update the `@require` URL for `funcs.js` to a new cache-busting reference, and increment the `cacheVersion` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.

### Testing

- Ran `node --check Episodes_Importer/funcs.js` and it returned successfully. 
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it returned successfully. 
- Ran `git diff --check` to ensure no whitespace/diff issues and it returned successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50c8b362fc8320b120548393a37fd3)