### PR TITLE
Fix Resident ID tracklist entries

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.1
+// @version      2026.07.10.2
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -25,7 +25,7 @@
  * global.js URL needs to be changed manually
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-var cacheVersion = 10,
+var cacheVersion = 11,
     scriptName = "Hernan_Cattaneo_Resident";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -133,6 +133,10 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return getFirstDescriptionParagraph(description) || description;
     }
 
+    function fixRawTracklistLine(line) {
+        return line.replace(/^(.*?\S\s+-\s+)ID$/i, '$1?');
+    }
+
     function renderTracklistApiFeedback(wrapper, tracklistResult) {
         const source = getTracklistSourceNode(wrapper);
         if (!source) return;
@@ -171,6 +175,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             .split('\n')
             .map(importer.normalizeTracklistLine)
             .filter(Boolean)
+            .map(fixRawTracklistLine)
             .join('\n');
     }
 


### PR DESCRIPTION
### Motivation
- Prevent raw tracklist lines like `Roman - ID` from being sent unchanged to the Tracklist Editor API by converting `- ID` to `- ?` before formatting.
- Bump the userscript version/cache so deployments pick up the change immediately.

### Description
- Bumped the userscript `@version` to `2026.07.10.2` and `cacheVersion` to `11` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Added a helper function `fixRawTracklistLine` that applies the regex `line.replace(/^(.*?\S\s+-\s+)ID$/i, '$1?')` to convert trailing `ID` to `?`.
- Applied `.map(fixRawTracklistLine)` in `extractRawTracklist` after `normalizeTracklistLine` so the fix runs before the Tracklist Editor API is called.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` which completed without errors.
- Ran `git diff --check` which returned no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50cb9161f48320a94fdd00c22918b8)