### PR TITLE
Refresh MixesDB creation link on click (use current tracklist textarea)

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.6
+// @version      2026.07.10.7
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.10.1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.10.2
 // @include      https://podcast.hernancattaneo.com*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hernancattaneo.com
@@ -255,6 +255,18 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             const tracklist = await importer.formatTracklist(rawTracklist, config.tleApiType);
             renderTracklistApiFeedback(wrapper, tracklist);
             link.href = importer.buildMixesdbUrl(title, episodeUrl, buildEpisodePageText(episode, tracklist, extractPlayerUrl(wrapper)));
+            importer.updateMixesdbCreateLinkOnClick(link, {
+                title,
+                episodeUrl,
+                getInsertText: () => buildEpisodePageText(
+                    episode,
+                    {
+                        text: wrapper.querySelector(`.${config.classNames.apiTracklist}`)?.value || tracklist.text,
+                        status: tracklist.status,
+                    },
+                    extractPlayerUrl(wrapper)
+                ),
+            });
         } catch (error) {
             importer.logValue('Failed to format Resident tracklist for MixesDB', error.message || error);
             const fallbackTracklist = importer.hasTracklistForApi(rawTracklist)
@@ -263,6 +275,18 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             const fallbackStatus = importer.hasTracklistForApi(rawTracklist) ? 'incomplete' : 'none';
             renderTracklistApiFeedback(wrapper, { feedback: null });
             link.href = importer.buildMixesdbUrl(title, episodeUrl, buildEpisodePageText(episode, { text: fallbackTracklist, status: fallbackStatus }, extractPlayerUrl(wrapper)));
+            importer.updateMixesdbCreateLinkOnClick(link, {
+                title,
+                episodeUrl,
+                getInsertText: () => buildEpisodePageText(
+                    episode,
+                    {
+                        text: wrapper.querySelector(`.${config.classNames.apiTracklist}`)?.value || fallbackTracklist,
+                        status: fallbackStatus,
+                    },
+                    extractPlayerUrl(wrapper)
+                ),
+            });
         }
         link.className = `${config.classNames.link} is-missing`;
         link.textContent = 'Copy to MixesDB';

--- a/Episodes_Importer/funcs.js
+++ b/Episodes_Importer/funcs.js
@@ -158,6 +158,25 @@
         return url.toString();
     }
 
+    function resolveValue(value, fallback = '') {
+        return typeof value === 'function' ? value() : (value || fallback);
+    }
+
+    function updateMixesdbCreateLinkOnClick(link, options = {}) {
+        if (!link || link.dataset.mdbCreateLinkTextUpdater === '1') return;
+
+        link.dataset.mdbCreateLinkTextUpdater = '1';
+        link.addEventListener('click', () => {
+            const title = resolveValue(options.title || options.getTitle);
+            const episodeUrl = resolveValue(options.episodeUrl || options.getEpisodeUrl, location.href);
+            const insertText = resolveValue(options.insertText || options.getInsertText);
+
+            if (!title || !insertText) return;
+
+            link.href = buildMixesdbUrl(title, episodeUrl, insertText);
+        });
+    }
+
     function insertMixesdbTextFromUrl() {
         const params = new URLSearchParams(location.search);
         const action = params.get('action');
@@ -190,6 +209,7 @@
         getNodeTextWithLinebreaks,
         hasTracklistForApi,
         insertMixesdbTextFromUrl,
+        updateMixesdbCreateLinkOnClick,
         logValue,
         normalizeTracklistLine,
         padNumber,


### PR DESCRIPTION
### Motivation
- Ensure the "Copy to MixesDB" link uses the current tracklist textarea value when clicked so users can edit the text before opening MixesDB. 
- Provide a reusable, global helper in `Episodes_Importer/funcs.js` so other importers can adopt the same behavior.

### Description
- Added `resolveValue` and `updateMixesdbCreateLinkOnClick` helpers to `Episodes_Importer/funcs.js` to rebuild `insertText` at click time from either static values or functions. 
- Exported `updateMixesdbCreateLinkOnClick` via `window.MixesDBEpisodesImporter` for other scripts to call. 
- Updated `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` to call `importer.updateMixesdbCreateLinkOnClick(link, {...})` so the MixesDB URL is rebuilt on click using the current Tracklist Editor textarea content (both API and fallback paths). 
- Bumped the Hernan Cattaneo Resident userscript version and the `funcs.js` cache-buster URL to the new date-based version.

### Testing
- Ran `node --check Episodes_Importer/funcs.js` and it succeeded. 
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it succeeded. 
- Ran `git diff --check` and there were no check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5107e9c61083208278fb9115f40cc2)