### PR TITLE
Fix Resident create link navigation

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.9
+// @version      2026.07.10.10
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -25,7 +25,7 @@
  * global.js URL needs to be changed manually
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-var cacheVersion = 12,
+var cacheVersion = 13,
     scriptName = "Hernan_Cattaneo_Resident";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -254,13 +254,14 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.addEventListener('click', async event => {
             event.preventDefault();
             markLinkVisited(link);
-            const targetWindow = window.open('about:blank', link.target || '_blank', 'noopener,noreferrer');
+            const targetWindow = window.open('', link.target || '_blank');
             const tracklist = await getTracklistForCreate(wrapper, fallbackTracklist, fallbackStatus);
             const insertText = buildEpisodePageText(episode, tracklist, extractPlayerUrl(wrapper));
             setCreateLinkHref(link, title, episodeUrl, insertText);
 
             if (targetWindow) {
-                targetWindow.location.href = link.href;
+                targetWindow.opener = null;
+                targetWindow.location.replace(link.href);
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- The create buttons opened a new `about:blank` tab and left it open while the script asynchronously prepared the MixesDB content, resulting in a blank tab instead of navigating to the generated page.
- Ensure the created tab is reused and replaced with the final MixesDB URL once the tracklist and insert text are ready.

### Description
- Bumped userscript version to `2026.07.10.10` and increased `cacheVersion` to `13` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Changed the create-link click flow to call `window.open('', link.target || '_blank')` so a controllable window handle is returned immediately instead of an explicit `about:blank` with `noopener` attributes.
- After preparing the async insert text, the code now nulls `targetWindow.opener` and calls `targetWindow.location.replace(link.href)` to avoid leaving a blank tab open and to safely replace the temporary tab with the generated MixesDB URL; the previous fallback `window.open(link.href, ...)` remains for cases where a handle wasn't obtained.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it succeeded.
- Ran `git diff --check` and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5132a7bc848320aad372b238f074b5)