### PR TITLE
Fix Resident MP3 player URL extraction

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.10
+// @version      2026.07.10.11
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -25,7 +25,7 @@
  * global.js URL needs to be changed manually
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-var cacheVersion = 13,
+var cacheVersion = 14,
     scriptName = "Hernan_Cattaneo_Resident";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -199,10 +199,21 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         }
     }
 
+    function getPlayerCandidateUrl(player) {
+        return player.href
+            || player.src
+            || player.getAttribute('href')
+            || player.getAttribute('src')
+            || '';
+    }
+
     function extractPlayerUrl(wrapper) {
-        const player = wrapper.querySelector(config.selectors.player);
-        const playerUrl = player ? (player.href || player.src || '') : '';
-        return isValidPlayerUrl(playerUrl) ? new URL(playerUrl, location.href).toString() : '';
+        const players = Array.from(wrapper.querySelectorAll(config.selectors.player));
+        const validPlayerUrl = players
+            .map(getPlayerCandidateUrl)
+            .find(isValidPlayerUrl);
+
+        return validPlayerUrl ? new URL(validPlayerUrl, location.href).toString() : '';
     }
 
     function buildEpisodePageText(episode, tracklistResult, playerUrl = '') {
@@ -276,7 +287,8 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     function getDownloadLink(wrapper) {
-        return wrapper.querySelector('a[href*=".mp3"]');
+        return Array.from(wrapper.querySelectorAll('a[href*=".mp3"]'))
+            .find(link => isValidPlayerUrl(link.href || link.getAttribute('href')));
     }
 
     function placeCopyLink(link, wrapper) {


### PR DESCRIPTION
### Motivation
- The page `{{Player}}` URL was sometimes omitted because the importer stopped at the first matched player element which could be a placeholder or invalid URL. 
- Download-link placement also used the first anchor match even when it pointed to an invalid/placeholder URL. 
- The userscript version and CSS cache needed bumping for today's release.

### Description
- Bumped the Hernan Cattaneo Resident userscript `@version` to `2026.07.10.11` and incremented `cacheVersion` from `13` to `14` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Added `getPlayerCandidateUrl(player)` to normalize candidate URL retrieval from matched nodes.
- Rewrote `extractPlayerUrl(wrapper)` to scan all elements matching `config.selectors.player`, map to candidate URLs and use the first URL that passes `isValidPlayerUrl`.
- Updated `getDownloadLink(wrapper)` to find the first valid `.mp3` anchor (skipping invalid/placeholder links) before placing the copy link.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff issues, which passed. 
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` to validate syntax, which passed. 
- Changes were committed to the repository (`Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5133bfeabc8320bc8da227ea5e2335)