### PR TITLE
Fix Resident edited tracklist copy feedback

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.10
+// @version      2026.07.10.11
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -220,27 +220,13 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return wrapper.querySelector(`.${config.classNames.apiTracklist}`)?.value || fallbackTracklist;
     }
 
-    async function getTracklistForCreate(wrapper, fallbackTracklist, fallbackStatus) {
+    function getTracklistForCreate(wrapper, fallbackTracklist, fallbackStatus) {
         const editorTracklist = getEditorTracklist(wrapper, fallbackTracklist);
 
-        if (!editorTracklist || editorTracklist === fallbackTracklist) {
-            return {
-                text: fallbackTracklist,
-                status: fallbackStatus,
-            };
-        }
-
-        try {
-            const tracklist = await importer.formatTracklist(editorTracklist, config.tleApiType);
-            renderTracklistApiFeedback(wrapper, tracklist);
-            return tracklist;
-        } catch (error) {
-            importer.logValue('Failed to reformat edited Resident tracklist for MixesDB', error.message || error);
-            return {
-                text: editorTracklist,
-                status: fallbackStatus,
-            };
-        }
+        return {
+            text: editorTracklist || fallbackTracklist,
+            status: fallbackStatus,
+        };
     }
 
     function setCreateLinkHref(link, title, episodeUrl, insertText) {


### PR DESCRIPTION
### Motivation

- Edited tracklists submitted via the textarea were being re-submitted to the Tracklist Editor API when opening the MixesDB create/copy link, which caused the API feedback to be re-rendered as a misleading green “No changes were made.” state.

### Description

- Bumped the userscript `// @version` to `2026.07.10.11` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Replaced the async `getTracklistForCreate` implementation with a synchronous version that returns `{ text: editorTracklist || fallbackTracklist, status: fallbackStatus }` and no longer calls `importer.formatTracklist`.
- Stopped re-submitting edited textarea content to the TLE API from the create-link flow so existing TLE feedback is not overwritten when the user clicks the copy/create link.

### Testing

- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it completed without syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5134adaa448320a4cb47b8e2474e19)