### PR TITLE
Fix Resident create-link delay timing

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.12
+// @version      2026.07.10.13
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -253,10 +253,17 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             };
         }
 
-        return {
-            text: editorTracklist,
-            status: fallbackStatus,
-        };
+        try {
+            const updatedTracklist = await importer.formatTracklist(editorTracklist, config.tleApiType);
+            renderTracklistApiFeedback(wrapper, updatedTracklist);
+            return updatedTracklist;
+        } catch (error) {
+            importer.logValue('Failed to refresh Resident tracklist feedback for MixesDB', error.message || error);
+            return {
+                text: editorTracklist,
+                status: fallbackStatus,
+            };
+        }
     }
 
     function setCreateLinkHref(link, title, episodeUrl, insertText) {
@@ -270,19 +277,11 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.addEventListener('click', async event => {
             event.preventDefault();
             markLinkVisited(link);
-            const targetWindow = window.open('', link.target || '_blank');
             const tracklist = await getTracklistForCreate(wrapper, fallbackTracklist, fallbackStatus);
             const insertText = buildEpisodePageText(episode, tracklist, extractPlayerUrl(wrapper));
             setCreateLinkHref(link, title, episodeUrl, insertText);
             showCreateLinkDelayFeedback(wrapper);
             await waitBeforeOpeningCreateLink();
-
-            if (targetWindow) {
-                targetWindow.opener = null;
-                targetWindow.location.replace(link.href);
-                return;
-            }
-
             window.open(link.href, link.target || '_blank', 'noopener,noreferrer');
         });
     }


### PR DESCRIPTION
### Motivation

- Ensure the MixesDB create-flow waits for Tracklist Editor (TLE) feedback to be refreshed on the source episode page instead of opening an `about:blank` tab early. 
- Refresh formatted tracklist feedback when a user has edited the TL box so the page shows up-to-date TLE feedback before opening the MixesDB create URL.

### Description

- Bumped the userscript version in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` to `2026.07.10.13`.
- Updated `getTracklistForCreate` to call `importer.formatTracklist` on the edited TL text and call `renderTracklistApiFeedback` so TLE feedback is refreshed, and wrapped the call in a `try/catch` that logs failures and falls back to the editor text.
- Removed the intermediate `about:blank` window open logic from the click handler and now open the final MixesDB URL only after the TLE refresh and the small delay, using `window.open(link.href, ...)`.

### Testing

- Ran `git diff --check` which passed without issues.
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513872d6548320b208959e2fe13fc1)