### PR TITLE
Fix Resident podcast title parsing

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.14
+// @version      2026.07.10.15
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -102,18 +102,32 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     function parseEpisodeTitle(title) {
-        const match = title.match(/Resident\s*\/\s*Episode\s*(\d+)\s*\/\s*([A-Za-z]+)\s+(\d{1,2})\s+(\d{4})/i);
-        if (!match) return null;
+        const slashTitleMatch = title.match(/Resident\s*\/\s*Episode\s*(\d+)\s*\/\s*([A-Za-z]+)\s+(\d{1,2})\s+(\d{4})/i);
+        if (slashTitleMatch) {
+            const episodeNumber = Number(slashTitleMatch[1]);
+            const month = importer.getMonthNumber(slashTitleMatch[2]);
+            if (!month || !episodeNumber) return null;
 
-        const episodeNumber = Number(match[1]);
-        const month = importer.getMonthNumber(match[2]);
-        if (!month || !episodeNumber) return null;
+            return {
+                episodeNumber,
+                date: `${slashTitleMatch[4]}-${month}-${String(slashTitleMatch[3]).padStart(2, '0')}`,
+                year: slashTitleMatch[4],
+            };
+        }
 
-        return {
-            episodeNumber,
-            date: `${match[4]}-${month}-${String(match[3]).padStart(2, '0')}`,
-            year: match[4],
-        };
+        const podcastTitleMatch = title.match(/^(\d+)\s+Hernan\s+Cattaneo\s+podcast\s+-\s+(\d{4})-(\d{2})-(\d{2})\b/i);
+        if (podcastTitleMatch) {
+            const episodeNumber = Number(podcastTitleMatch[1]);
+            if (!episodeNumber) return null;
+
+            return {
+                episodeNumber,
+                date: `${podcastTitleMatch[2]}-${podcastTitleMatch[3]}-${podcastTitleMatch[4]}`,
+                year: podcastTitleMatch[2],
+            };
+        }
+
+        return null;
     }
 
     function buildMixesdbTitle(episode) {


### PR DESCRIPTION
### Motivation
- The importer only handled the `Resident / Episode …` title form and missed pages titled like `680 Hernan Cattaneo podcast - 2024-05-18`, so episode number and date detection failed for that format.

### Description
- Bumped the Hernan Cattaneo Resident userscript version to `2026.07.10.15` in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Updated `parseEpisodeTitle` to first parse the existing `Resident / Episode 649 / Oct 14 2023` slash format and then also support the `680 Hernan Cattaneo podcast - 2024-05-18` podcast-title format, returning `{ episodeNumber, date, year }` or `null` when no match is found.
- No other behavioural changes were introduced and downstream title building still uses `buildMixesdbTitle` unchanged.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it succeeded.
- Executed a Node snippet that asserts parsing of both `Resident / Episode 649 / Oct 14 2023` and `680 Hernan Cattaneo podcast - 2024-05-18` and the assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513bcbbd34832083143d9f117fd3c9)