### PR TITLE
Remove country/city qualifiers from artist names before TLE API submission

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.10.16
+// @version      2026.07.10.17
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.10.2
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_17
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.10.3
 // @include      https://podcast.hernancattaneo.com*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hernancattaneo.com
@@ -25,7 +25,7 @@
  * global.js URL needs to be changed manually
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-var cacheVersion = 16,
+var cacheVersion = 17,
     scriptName = "Hernan_Cattaneo_Resident";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );

--- a/Episodes_Importer/funcs.js
+++ b/Episodes_Importer/funcs.js
@@ -1,4 +1,4 @@
-/* global log, logVar */
+/* global artistLocationCityNames, artistLocationCountryCodes, log, logVar */
 (function () {
     'use strict';
 
@@ -89,6 +89,33 @@
         return rawTracklist.split('\n').filter(Boolean).length >= minimumLines;
     }
 
+    function getArtistLocationQualifiers() {
+        const countryCodes = typeof artistLocationCountryCodes !== 'undefined' ? artistLocationCountryCodes : [];
+        const cityNames = typeof artistLocationCityNames !== 'undefined' ? artistLocationCityNames : [];
+        return new Set([...countryCodes, ...cityNames].map(qualifier => String(qualifier).toLowerCase()));
+    }
+
+    function removeArtistLocationQualifiers(line) {
+        const separator = line.match(/\s+-\s+/);
+        if (!separator) return line;
+
+        const artist = line.slice(0, separator.index);
+        const title = line.slice(separator.index);
+        const locationQualifiers = getArtistLocationQualifiers();
+        const sanitizedArtist = artist.replace(/\s*\(([^()]+)\)/g, (match, qualifier) => {
+            return locationQualifiers.has(String(qualifier).trim().toLowerCase()) ? '' : match;
+        });
+
+        return `${sanitizedArtist}${title}`.replace(/\s+/g, ' ').trim();
+    }
+
+    function removeTracklistArtistLocationQualifiers(rawTracklist) {
+        return rawTracklist
+            .split('\n')
+            .map(removeArtistLocationQualifiers)
+            .join('\n');
+    }
+
     function getFeedbackTracklistStatus(feedback) {
         if (!feedback) return 'incomplete';
         if (feedback.warnings > 0 || feedback.hints > 0 || feedback.status === 'incomplete') return 'incomplete';
@@ -100,11 +127,12 @@
             return { text: '<list>\n\n</list>', status: 'none', feedback: null };
         }
 
-        logMessage('Tracklist before Tracklist Editor API:\n' + rawTracklist);
+        const apiTracklistText = removeTracklistArtistLocationQualifiers(rawTracklist);
+        logMessage('Tracklist before Tracklist Editor API:\n' + apiTracklistText);
 
         if (typeof apiTracklist === 'function') {
-            const apiResult = apiTracklist(rawTracklist, apiType);
-            const formattedTracklist = apiResult.text || rawTracklist.split('\n').map(line => `# ${line}`).join('\n');
+            const apiResult = apiTracklist(apiTracklistText, apiType);
+            const formattedTracklist = apiResult.text || apiTracklistText.split('\n').map(line => `# ${line}`).join('\n');
             logMessage('Tracklist after Tracklist Editor API:\n' + formattedTracklist);
             return { text: formattedTracklist, status: getFeedbackTracklistStatus(apiResult.feedback), feedback: apiResult.feedback || null };
         }
@@ -112,7 +140,7 @@
         const body = new URLSearchParams({
             query: 'tracklistEditor',
             type: apiType,
-            text: rawTracklist,
+            text: apiTracklistText,
         });
 
         const response = await fetch(tracklistApiUrl, {
@@ -126,7 +154,7 @@
         }
 
         const data = await response.json();
-        const formattedTracklist = data.text || rawTracklist.split('\n').map(line => `# ${line}`).join('\n');
+        const formattedTracklist = data.text || apiTracklistText.split('\n').map(line => `# ${line}`).join('\n');
         logMessage('Tracklist after Tracklist Editor API:\n' + formattedTracklist);
         return { text: formattedTracklist, status: getFeedbackTracklistStatus(data.feedback), feedback: data.feedback || null };
     }
@@ -205,6 +233,8 @@
         buildMixesdbUrl,
         fetchExistingEpisodes,
         formatTracklist,
+        removeArtistLocationQualifiers,
+        removeTracklistArtistLocationQualifiers,
         getMonthNumber,
         getNodeTextWithLinebreaks,
         hasTracklistForApi,

--- a/includes/global.js
+++ b/includes/global.js
@@ -16,6 +16,24 @@ const TLbox = '<div class="Mixeswiki_WebTracklistsToCopy MixesDB_WebTracklistsTo
 const msFadeSlow = 800;
 const msWaitToggle = 200;
 
+// Location qualifiers that some sources append to artist names, e.g.
+// "Felipe Garcia (UY)" or "PAAX (Tulum)".
+const artistLocationCountryCodes = [
+    'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AO', 'AQ', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ',
+    'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BV', 'BW', 'BY', 'BZ',
+    'CA', 'CC', 'CD', 'CF', 'CG', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN', 'CO', 'CR', 'CU', 'CV', 'CW', 'CX', 'CY', 'CZ',
+    'DE', 'DJ', 'DK', 'DM', 'DO', 'DZ', 'EC', 'EE', 'EG', 'EH', 'ER', 'ES', 'ET', 'FI', 'FJ', 'FK', 'FM', 'FO', 'FR',
+    'GA', 'GB', 'GD', 'GE', 'GF', 'GG', 'GH', 'GI', 'GL', 'GM', 'GN', 'GP', 'GQ', 'GR', 'GS', 'GT', 'GU', 'GW', 'GY',
+    'HK', 'HM', 'HN', 'HR', 'HT', 'HU', 'ID', 'IE', 'IL', 'IM', 'IN', 'IO', 'IQ', 'IR', 'IS', 'IT', 'JE', 'JM', 'JO', 'JP',
+    'KE', 'KG', 'KH', 'KI', 'KM', 'KN', 'KP', 'KR', 'KW', 'KY', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS', 'LT', 'LU', 'LV', 'LY',
+    'MA', 'MC', 'MD', 'ME', 'MF', 'MG', 'MH', 'MK', 'ML', 'MM', 'MN', 'MO', 'MP', 'MQ', 'MR', 'MS', 'MT', 'MU', 'MV', 'MW', 'MX', 'MY', 'MZ',
+    'NA', 'NC', 'NE', 'NF', 'NG', 'NI', 'NL', 'NO', 'NP', 'NR', 'NU', 'NZ', 'OM', 'PA', 'PE', 'PF', 'PG', 'PH', 'PK', 'PL', 'PM', 'PN', 'PR', 'PS', 'PT', 'PW', 'PY',
+    'QA', 'RE', 'RO', 'RS', 'RU', 'RW', 'SA', 'SB', 'SC', 'SD', 'SE', 'SG', 'SH', 'SI', 'SJ', 'SK', 'SL', 'SM', 'SN', 'SO', 'SR', 'SS', 'ST', 'SV', 'SX', 'SY', 'SZ',
+    'TC', 'TD', 'TF', 'TG', 'TH', 'TJ', 'TK', 'TL', 'TM', 'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'UM', 'US', 'UY', 'UZ',
+    'VA', 'VC', 'VE', 'VG', 'VI', 'VN', 'VU', 'WF', 'WS', 'YE', 'YT', 'ZA', 'ZM', 'ZW',
+];
+const artistLocationCityNames = ['Tulum'];
+
 // toolkitUrls_totalTimeout
 // fires additionally after playerUrlItems_timeout
 // must be at least SoundCloud API response time


### PR DESCRIPTION
### Motivation
- Some tracklist sources append country codes or city names in parentheses to artist names (e.g. `Felipe Garcia (UY)`, `PAAX (Tulum)`), which should be removed before sending to the Tracklist Editor API.
- Provide a shared source for qualifiers so multiple importers can reuse the same lists.
- Ensure the Hernan Cattaneo Resident userscript reflects the change and is version-bumped for today.

### Description
- Added `artistLocationCountryCodes` and `artistLocationCityNames` constants to `includes/global.js` to hold ISO-like country codes and known city qualifiers such as `Tulum`.
- Implemented `getArtistLocationQualifiers`, `removeArtistLocationQualifiers`, and `removeTracklistArtistLocationQualifiers` in `Episodes_Importer/funcs.js` to strip bracketed qualifiers from the artist portion of lines like `Artist (QUAL) - Title`.
- Updated `formatTracklist` in `Episodes_Importer/funcs.js` to run the tracklist through the sanitizer before calling the Tracklist Editor API and to use the sanitized text for fallback formatting.
- Exposed the new sanitizer helpers through `window.MixesDBEpisodesImporter` for reuse and testing, and bumped the Hernan Cattaneo Resident userscript cache/version references and `cacheVersion` to today's date.

### Testing
- Ran `node --check Episodes_Importer/funcs.js` and it succeeded.
- Ran `node --check includes/global.js` and it succeeded.
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` and it succeeded.
- Executed a functional Node test that loaded the importer and verified `removeTracklistArtistLocationQualifiers` converts `Felipe Garcia (UY) - Foggy Days\nPAAX (Tulum) - Deep Into The Mountain` into `Felipe Garcia - Foggy Days\nPAAX - Deep Into The Mountain`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513f5862748320b5d2b281157fef87)