### PR TITLE
Fade copied Hernan Cattaneo Resident episodes

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.11.1
+// @version      2026.07.11.2
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -66,6 +66,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             apiFeedback: 'mdb-resident-tle-feedback',
             apiTracklist: 'mdb-resident-tle-tracklist',
             copyWaiter: 'mdb-resident-copy-waiter',
+            copiedWrapper: 'mdb-resident-copied-wrapper',
         },
         manualExistingEpisodes: [
             714, 715, 716,
@@ -333,6 +334,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.addEventListener('click', async event => {
             event.preventDefault();
             markLinkVisited(link);
+            wrapper.classList.add(config.classNames.copiedWrapper);
             const waiter = showCreateLinkWaiter(link);
             try {
                 const { tracklist, refreshedFeedback } = await getTracklistForCreate(wrapper, fallbackTracklist, fallbackStatus);
@@ -492,11 +494,25 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         wrapper.append(createEpisodeCloseButton());
     }
 
+    function restoreCopiedWrapperOnClick(wrapper) {
+        if (wrapper.dataset.mdbResidentCopiedOpacityRestorer === '1') return;
+
+        wrapper.dataset.mdbResidentCopiedOpacityRestorer = '1';
+        wrapper.addEventListener('click', event => {
+            if (event.target.closest(`.${config.classNames.link}.is-missing`)) return;
+
+            wrapper.classList.remove(config.classNames.copiedWrapper);
+        });
+    }
+
     function addStyles() {
         const style = document.createElement('style');
         style.textContent = `
             ${config.selectors.episodeWrapper}[data-mdb-episode-number] {
                 position: relative;
+            }
+            ${config.selectors.episodeWrapper}.${config.classNames.copiedWrapper} {
+                opacity: 0.5;
             }
             .${config.classNames.closeButton} {
                 align-items: center;
@@ -645,6 +661,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             if (!episode) return;
 
             wrapper.dataset.mdbEpisodeNumber = String(episode.episodeNumber);
+            restoreCopiedWrapperOnClick(wrapper);
             addEpisodeCloseButton(wrapper);
             heading.dataset.mdbImporterProcessed = 'true';
             heading.insertAdjacentElement('afterend', createMixesdbLink(heading, episode, wrapper));


### PR DESCRIPTION
### Motivation
- Provide clear visual feedback when a user clicks the “Copy to MixesDB” action by dimming the corresponding episode wrapper, and allow restoring the wrapper opacity on subsequent clicks inside the wrapper while avoiding immediate reset from the copy button click itself.

### Description
- Bumped the userscript version to `2026.07.11.2`.
- Added `copiedWrapper` to `config.classNames` and apply it to the episode wrapper when the create/copy link is clicked via `wrapper.classList.add(config.classNames.copiedWrapper)`.
- Added CSS for `${config.selectors.episodeWrapper}.${config.classNames.copiedWrapper}` to set `opacity: 0.5`.
- Introduced `restoreCopiedWrapperOnClick(wrapper)` to remove the copied class on wrapper clicks (ignoring clicks on the copy link) and invoked it when initializing episode wrappers.

### Testing
- Ran `git diff --check` which completed with no issues.
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5215b4eeb083208185d9aaca776dbb)