### PR TITLE
Handle Hernan slash-date episode titles

### DIFF
--- a/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.11.9
+// @version      2026.07.11.10
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -161,7 +161,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
 
     function parseEpisodeTitle(title) {
         logStep('parseEpisodeTitle input', title);
-        const slashTitleMatch = title.match(/Resident\s*\/\s*Episode\s*(\d+)\s*\/\s*([A-Za-z]+)\s+(\d{1,2})\s+(\d{4})/i);
+        const slashTitleMatch = title.match(/Resident\s*\/\s*Episode\s*(\d+)\s*\/\s*([A-Za-z]+)\s+(\d{1,2})(?:\s*\/)?\s+(\d{4})/i);
         if (slashTitleMatch) {
             const episodeNumber = Number(slashTitleMatch[1]);
             const monthName = slashTitleMatch[2];


### PR DESCRIPTION
### Motivation
- Allow the Hernan Cattaneo Resident importer to correctly parse slash-style episode headings that include an extra slash before the year (e.g. `Resident / Episode 250 / Feb 20 / 2016`) and record a version bump for the userscript.

### Description
- Adjusted the `parseEpisodeTitle` regex in `Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` to accept an optional slash before the year and bumped the userscript header `@version` to `2026.07.11.10`.

### Testing
- Ran `node --check Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js` which succeeded. 
- Executed a Python regex check that validated both `Resident / Episode 250 / Feb 20 / 2016` and `Resident / Episode 250 / Feb 20 2016` formats, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a522b04e6688320808b7205839d2ebb)