### PR TITLE
Point private userscripts to new main/private raw URLs and bump versions

### DIFF
--- a/private/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+++ b/private/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
@@ -1,16 +1,16 @@
 // ==UserScript==
 // @name         Hernan Cattaneo Resident (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.11.11
+// @version      2026.07.14.1
 // @description  Add MixesDB creation links to Hernan Cattaneo Resident podcast episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
-// @updateURL    https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
-// @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+// @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
+// @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Hernan_Cattaneo_Resident_22
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Episodes_Importer/funcs.js?v-2026.07.11.2
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.14.1
 // @include      https://podcast.hernancattaneo.com*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hernancattaneo.com

--- a/private/Player_URLs/Apple_Podcasts/script.user.js
+++ b/private/Player_URLs/Apple_Podcasts/script.user.js
@@ -1,8 +1,9 @@
 // ==UserScript==
 // @name         Apple Podcasts Player URLs (private)
-// @version      2026.07.10.4
+// @version      2026.07.14.1
 // @description  Add Apple Podcasts player URLs from array to mix pages when episode numbers match the mix page title
-// @updateURL    https://raw.githubusercontent.com/Subfader/Private-userscripts/refs/heads/main/Apple_Podcasts_Player_URLs/user.script.js
+// @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/Apple_Podcasts/script.user.js
+// @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/Apple_Podcasts/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Players_Helper_7

--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,8 +1,9 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.13.13
+// @version      2026.07.14.1
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
-// @updateURL    https://raw.githubusercontent.com/Subfader/Private-userscripts/refs/heads/main/YouTube_Player_URLs/user.script.js
+// @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
+// @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_Player_URLs_1


### PR DESCRIPTION
### Motivation
- Private userscripts were moved into the repository under `main/private` so their metadata and internal @require paths must refer to the new locations and matching cache keys. 
- Versions should be bumped to reflect the update and follow the project rule to use today's date in the version.

### Description
- Updated `@updateURL` and added `@downloadURL` to point at `https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/...` for the private scripts `private/Player_URLs/Apple_Podcasts/script.user.js`, `private/Player_URLs/YouTube/script.user.js`, and `private/Episodes_Importer/Hernan_Cattaneo_Resident/script.user.js`.
- Bumped the `// @version` fields for the three modified userscripts to `2026.07.14.1`.
- Adjusted the internal `@require` for the Episodes Importer to `private/Episodes_Importer/funcs.js` and updated its cache key to `v-2026.07.14.1`.
- Committed the changes with message `Update private userscript raw paths`.

### Testing
- Ran `git diff --check` which completed with no issues and returned success.
- Ran `rg -n --pcre2 "Subfader/Private-userscripts|refs/heads/main/(Episodes_Importer|Apple_Podcasts_Player_URLs|YouTube_Player_URLs)" private` to verify no leftover old raw paths and it returned expected results (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a563544bb6c8320b30a0293a9dc0050)