### PR TITLE
Normalize YouTube episode/date keys and bump userscript version

### DIFF
--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.14.1
+// @version      2026.07.14.2
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js

--- a/private/Player_URLs/YouTube/youtube_ids.sh
+++ b/private/Player_URLs/YouTube/youtube_ids.sh
@@ -13,8 +13,8 @@ cd ~/Documents/GitHub/userscripts/private/Player_URLs/YouTube && bash youtube_id
 2) Copy episodes_arr.txt to the userscript
 This file could be loaded in the userscript but requires a Commit and the work is done locally anyways…
 
-Fetches a YouTube channel or playlist with yt-dlp and writes youtube_ids.txt
-in this directory as a JavaScript object of video titles to youtu.be URLs.
+Fetches a YouTube channel or playlist with yt-dlp and writes episodes_arr.txt
+in this directory as a JavaScript object of normalized episode/date keys to youtu.be URLs.
 USAGE
 }
 
@@ -54,9 +54,86 @@ yt-dlp \
 
 python3 - "${temp_json}" "${output_file}" <<'PY'
 import json
+import re
 import sys
+from datetime import date
 
 input_path, output_path = sys.argv[1:3]
+
+MONTHS = {
+    "jan": 1,
+    "january": 1,
+    "feb": 2,
+    "february": 2,
+    "mar": 3,
+    "march": 3,
+    "apr": 4,
+    "april": 4,
+    "may": 5,
+    "jun": 6,
+    "june": 6,
+    "jul": 7,
+    "july": 7,
+    "aug": 8,
+    "august": 8,
+    "sep": 9,
+    "sept": 9,
+    "september": 9,
+    "oct": 10,
+    "october": 10,
+    "nov": 11,
+    "november": 11,
+    "dec": 12,
+    "december": 12,
+}
+MONTH_PATTERN = "|".join(MONTHS)
+DATE_PATTERNS = [
+    # 1 July 2026 / 1st July 2026
+    re.compile(rf"\b(?P<day>\d{{1,2}})(?:st|nd|rd|th)?[ .-]+(?P<month>{MONTH_PATTERN})[a-z]*[ ,.-]+(?P<year>\d{{4}})\b", re.I),
+    # July 1 2026 / July 1st, 2026
+    re.compile(rf"\b(?P<month>{MONTH_PATTERN})[a-z]*[ .-]+(?P<day>\d{{1,2}})(?:st|nd|rd|th)?[,]?[ .-]+(?P<year>\d{{4}})\b", re.I),
+    # 2026-07-01 / 2026.07.01 / 2026/7/1
+    re.compile(r"\b(?P<year>\d{4})[-./](?P<month>\d{1,2})[-./](?P<day>\d{1,2})\b"),
+]
+EPISODE_PATTERNS = [
+    # Prefer numbers that look like explicit episode identifiers.
+    re.compile(r"\b(?:ep(?:isode)?|podcast|show|mix|session|number|no\.?|#)\s*[-.:#]?\s*(?P<episode>\d{1,5})\b", re.I),
+    # Fallback for titles such as "CLR Podcast 474 | FJAAK".
+    re.compile(r"\b(?P<episode>\d{1,5})\b"),
+]
+
+
+def parse_date(title):
+    for pattern in DATE_PATTERNS:
+        match = pattern.search(title)
+        if not match:
+            continue
+
+        year = int(match.group("year"))
+        day = int(match.group("day"))
+        month_value = match.group("month")
+        month = int(month_value) if month_value.isdigit() else MONTHS[month_value.lower()[:3]]
+
+        try:
+            return date(year, month, day).isoformat()
+        except ValueError:
+            continue
+
+    return None
+
+
+def parse_episode(title):
+    for pattern in EPISODE_PATTERNS:
+        match = pattern.search(title)
+        if match:
+            return match.group("episode")
+
+    return None
+
+
+def normalize_title_key(title):
+    return parse_date(title) or parse_episode(title) or title
+
 
 with open(input_path, "r", encoding="utf-8") as handle:
     data = json.load(handle)
@@ -76,7 +153,8 @@ with open(output_path, "w", encoding="utf-8") as handle:
         if not video_id or not title:
             continue
 
-        title_json = json.dumps(title, ensure_ascii=False)
+        normalized_title = normalize_title_key(title)
+        title_json = json.dumps(normalized_title, ensure_ascii=False)
         url_json = json.dumps(f"https://youtu.be/{video_id}", ensure_ascii=False)
         handle.write(f"    {title_json}: {url_json},\n")
 


### PR DESCRIPTION
### Motivation
- Make the generated map of YouTube videos easier to match against mix page titles by normalizing keys to either a ISO date (`YYYY-MM-DD`) or a concise episode number. 
- Avoid manual post-processing of titles with regex by embedding deterministic parsing into the generation step. 

### Description
- Update the `youtube_ids.sh` generator to write `episodes_arr.txt` (help text updated) with normalized episode/date keys instead of raw titles. 
- Add embedded Python normalization logic that first tries to parse dates (multiple common patterns) and falls back to episode number patterns, returning the original title only if neither matches. 
- Apply the normalized key when writing each `episodes_arr` entry (`title_json` now uses `normalize_title_key(title)`). 
- Bump the private YouTube userscript version to `2026.07.14.2`.

### Testing
- Ran `bash -n private/Player_URLs/YouTube/youtube_ids.sh` for a syntax check and it succeeded. 
- Verified the script help with `bash private/Player_URLs/YouTube/youtube_ids.sh --help >/tmp/youtube_ids_help.txt` and it executed successfully. 
- Compiled the embedded Python with `python3 -m py_compile /tmp/youtube_ids_embedded.py` and it passed. 
- Executed the embedded Python on a sample JSON input (`python3 /tmp/youtube_ids_embedded.py <sample-json> /tmp/youtube_ids_output.txt`) which produced normalized keys like `"474"` and `"2026-07-01"` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5639289c1083209e43e0146aee552d)