### PR TITLE
youtube_ids.sh: add cleanup option and sort normalized keys

### DIFF
--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.14.3
+// @version      2026.07.14.4
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js

--- a/private/Player_URLs/YouTube/youtube_ids.sh
+++ b/private/Player_URLs/YouTube/youtube_ids.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
     cat <<'USAGE'
-Usage: ./youtube_ids.sh CHANNEL_OR_PLAYLIST_URL
+Usage: ./youtube_ids.sh CHANNEL_OR_PLAYLIST_URL [cleanup=true|false]
 
 Requires yt-dlp to be installed.
 
@@ -16,7 +16,10 @@ cd ~/Documents/GitHub/userscripts/private/Player_URLs/YouTube && bash youtube_id
 This file could be loaded in the userscript but requires a Commit and the work is done locally anyways…
 
 Fetches a YouTube channel or playlist with yt-dlp and writes episodes_arr.txt
-in this directory as a JavaScript object of normalized episode/date keys to youtu.be URLs.
+in this directory as a JavaScript object of episode/date keys to youtu.be URLs.
+
+By default, cleanup=true normalizes keys and sorts items by key ascending.
+Use cleanup=false to keep original titles and yt-dlp order.
 USAGE
 }
 
@@ -25,7 +28,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     exit 0
 fi
 
-if [[ $# -ne 1 ]]; then
+if [[ $# -lt 1 || $# -gt 2 ]]; then
     usage >&2
     exit 1
 fi
@@ -46,6 +49,21 @@ temp_json="$(mktemp)"
 trap 'rm -f "${temp_json}"' EXIT
 
 url="$1"
+cleanup_arg="${2:-true}"
+
+case "${cleanup_arg}" in
+    true|cleanup=true)
+        cleanup="true"
+        ;;
+    false|cleanup=false)
+        cleanup="false"
+        ;;
+    *)
+        echo "Error: cleanup must be true, false, cleanup=true, or cleanup=false." >&2
+        usage >&2
+        exit 1
+        ;;
+esac
 
 yt-dlp \
     --ignore-errors \
@@ -54,13 +72,14 @@ yt-dlp \
     --dump-single-json \
     "${url}" > "${temp_json}"
 
-python3 - "${temp_json}" "${output_file}" <<'PY'
+python3 - "${temp_json}" "${output_file}" "${cleanup}" <<'PY'
 import json
 import re
 import sys
 from datetime import date
 
-input_path, output_path = sys.argv[1:3]
+input_path, output_path, cleanup_arg = sys.argv[1:4]
+cleanup = cleanup_arg == "true"
 
 MONTHS = {
     "jan": 1,
@@ -142,22 +161,37 @@ with open(input_path, "r", encoding="utf-8") as handle:
 
 entries = data.get("entries") or []
 
+items = []
+for entry in entries:
+    if not entry:
+        continue
+
+    video_id = entry.get("id")
+    title = entry.get("title")
+
+    if not video_id or not title:
+        continue
+
+    key = normalize_title_key(title) if cleanup else title
+    items.append((key, f"https://youtu.be/{video_id}"))
+
+def item_sort_key(item):
+    key = item[0]
+    if key.isdigit():
+        return (0, int(key))
+
+    return (1, key.casefold())
+
+
+if cleanup:
+    items.sort(key=item_sort_key)
+
 with open(output_path, "w", encoding="utf-8") as handle:
     handle.write("var episodes_arr = {\n")
 
-    for entry in entries:
-        if not entry:
-            continue
-
-        video_id = entry.get("id")
-        title = entry.get("title")
-
-        if not video_id or not title:
-            continue
-
-        normalized_title = normalize_title_key(title)
-        title_json = json.dumps(normalized_title, ensure_ascii=False)
-        url_json = json.dumps(f"https://youtu.be/{video_id}", ensure_ascii=False)
+    for key, url in items:
+        title_json = json.dumps(key, ensure_ascii=False)
+        url_json = json.dumps(url, ensure_ascii=False)
         handle.write(f"    {title_json}: {url_json},\n")
 
     handle.write("};\n")


### PR DESCRIPTION
### Motivation
- Provide an option to skip normalization and sorting when generating `episodes_arr.txt`, while preserving the default behavior that normalizes keys and sorts them ascending. 
- Ensure numeric episode identifiers sort numerically and non-numeric keys sort case-insensitively for predictable, human-friendly output when cleanup is enabled.

### Description
- Updated `youtube_ids.sh` usage and help to accept an optional `cleanup` parameter: `./youtube_ids.sh CHANNEL_OR_PLAYLIST_URL [cleanup=true|false]` with `cleanup=true` as the default. 
- Added robust argument parsing that accepts `true`/`false` and `cleanup=true`/`cleanup=false` forms and passes the resolved `cleanup` value into the embedded Python block. 
- Reworked the Python output generation to collect `(key, url)` items, use `normalize_title_key(title)` only when `cleanup` is enabled, and sort items when `cleanup` is `true` using `item_sort_key` which sorts digit-only keys numerically and other keys case-insensitively. 
- Bumped the YouTube Player URLs userscript version to `2026.07.14.4`.

### Testing
- Ran a syntax check with `bash -n private/Player_URLs/YouTube/youtube_ids.sh` which completed without errors. 
- Mocked `yt-dlp` and executed the script with default `cleanup` to verify normalized keys are produced and sorted (observed output order: `"2"`, `"10"`, `"2026-07-01"`). 
- Mocked `yt-dlp` and executed the script with `cleanup=false` to verify original titles and the original yt-dlp order are preserved (observed output used original titles). 
- Checked for diff/style issues with `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56424842ac8320a15d17c19ab4f1fd)