### PR TITLE
Add shared Player URL helpers and preferred mirror ordering

### DIFF
--- a/private/Player_URLs/Apple_Podcasts/script.user.js
+++ b/private/Player_URLs/Apple_Podcasts/script.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         Apple Podcasts Player URLs (private)
-// @version      2026.07.14.1
+// @version      2026.07.14.2
 // @description  Add Apple Podcasts player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/Apple_Podcasts/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/Apple_Podcasts/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Players_Helper_7
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.14.1
 // @match        https://www.mixesdb.com/*
 // @match        https://*podcasts.apple.com/*
 // @noframes
@@ -806,51 +807,6 @@ var episodes_arr = {
 "001.2": "https://podcasts.apple.com/de/podcast/resident-episode-001-2-may-7th-2011/id387385712?i=1000664916226",
 "001.1": "https://podcasts.apple.com/de/podcast/resident-episode-001-1-may-7th-2011/id387385712?i=1000664916085"
 };
-
-// addEditorButton
-function makeEditorButton( idName, buttonText, info ) {
-    var spanClass = "tool oo-ui-widget oo-ui-widget-enabled oo-ui-toggleWidget oo-ui-toggleWidget-off oo-ui-buttonElement oo-ui-buttonElement-frameless oo-ui-iconElement oo-ui-toggleButtonWidget",
-        linkWrapper = '<a class="oo-ui-buttonElement-button" title="'+info+'" accesskey="y"><span class="fa fa-lg fa-nothing has-label"></span><span class="oo-ui-labelElement-label">'+buttonText+'</span></a>',
-        button = '<span class="'+spanClass+'" id="'+idName+'">'+linkWrapper+'</span>';
-    return button;
-}
-
-function addApplePodcastUrlToPlayer( text, url ) {
-    return text.replace( /{{Player[^}]*}}/, function( player ) {
-        var lines = player.split( "\n" ),
-            header = lines.shift();
-
-        if( lines.length == 0 ) {
-            return header.replace( /^(\{\{Player)([^}]*)\|(?:1=)?(https?:\/\/.+)\}\}$/, function( match, templateStart, options, oldUrl ) {
-                if( options.indexOf( "mode=" ) == -1 ) {
-                    options = "|mode=mirrors" + options;
-                }
-                return templateStart + options + "\n |1=" + url + "\n |2=" + oldUrl + "\n}}";
-            });
-        }
-
-        if( header.indexOf( "mode=" ) == -1 && lines.length > 1 ) {
-            header = header.replace( /^{{Player/, "{{Player|mode=mirrors" );
-        }
-
-        var nextPlayerNumber = 2;
-        lines = lines.map(function( line ) {
-            return line
-                .replace( /^( \|)(\d+)(=https?:\/\/.+)$/, function( match, prefix, number, rest ) {
-                    var newNumber = parseInt( number, 10 ) + 1;
-                    nextPlayerNumber = Math.max( nextPlayerNumber, newNumber + 1 );
-                    return prefix + newNumber + rest;
-                })
-                .replace( /^( \|)(https?:\/\/.+)$/, function( match, prefix, rest ) {
-                    return prefix + ( nextPlayerNumber++ ) + "=" + rest;
-                });
-        });
-
-        lines.unshift( " |1="+url );
-        lines.unshift( header );
-        return lines.join( "\n" );
-    });
-}
 
 // replaceAndSave
 function replaceAndSave( mode, url="" ) {

--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.14.5
+// @version      2026.07.14.6
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_Player_URLs_1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.14.1
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes
@@ -177,92 +178,6 @@ var episodes_arr = {
     "474": "https://youtu.be/-eQenB-EZhA",
 };
 
-// addEditorButton
-function makeEditorButton( idName, buttonText, info ) {
-    var button = document.createElement( "span" ),
-        linkWrapper = document.createElement( "a" ),
-        icon = document.createElement( "span" ),
-        label = document.createElement( "span" );
-
-    button.className = "tool oo-ui-widget oo-ui-widget-enabled oo-ui-toggleWidget oo-ui-toggleWidget-off oo-ui-buttonElement oo-ui-buttonElement-frameless oo-ui-iconElement oo-ui-toggleButtonWidget";
-    button.id = idName;
-
-    linkWrapper.className = "oo-ui-buttonElement-button";
-    linkWrapper.title = info;
-    linkWrapper.accessKey = "y";
-
-    icon.className = "fa fa-lg fa-nothing has-label";
-
-    label.className = "oo-ui-labelElement-label";
-    label.textContent = buttonText;
-
-    linkWrapper.append( icon, label );
-    button.append( linkWrapper );
-
-    return button;
-}
-
-function playerHeaderWithVideoAudio( header ) {
-    if( header.indexOf( "video=" ) == -1 ) {
-        header = header.replace( /^{{Player((?:\|mode=[^|\n}]+)?)/, "{{Player$1|video=audio" );
-    }
-    return header;
-}
-
-function playerUrlLine( url, number ) {
-    return " |" + ( url.indexOf( "=" ) == -1 ? "" : number + "=" ) + url;
-}
-
-function playerUrlValue( line ) {
-    var match = line.match( /^ \|(?:\d+=)?(https?:\/\/.+)$/ );
-    return match ? match[1] : "";
-}
-
-function newPlayerTemplate( url ) {
-    return "{{Player|video=audio\n" + playerUrlLine( url, 1 ) + "\n}}";
-}
-
-function addYouTubeUrlToPlayer( text, url ) {
-    return text.replace( /{{Player[^}]*}}/, function( player ) {
-        var lines = player.split( "\n" ),
-            header = playerHeaderWithVideoAudio( lines.shift() ),
-            urlLines = [],
-            footerLines = [];
-
-        if( lines.length == 0 ) {
-            return header.replace( /^(\{\{Player)([^}]*)\|(?:1=)?(https?:\/\/.+)\}\}$/, function( match, templateStart, options, oldUrl ) {
-                var urls = [ url, oldUrl ];
-                if( options.indexOf( "mode=" ) == -1 ) {
-                    options = "|mode=mirrors" + options;
-                }
-                header = playerHeaderWithVideoAudio( templateStart + options );
-                return header + "\n" + urls.map(function( thisUrl, index ) {
-                    return playerUrlLine( thisUrl, index + 1 );
-                }).join( "\n" ) + "\n}}";
-            });
-        }
-
-        lines.forEach(function( line ) {
-            if( playerUrlValue( line ) ) {
-                urlLines.push( line );
-            } else {
-                footerLines.push( line );
-            }
-        });
-
-        if( header.indexOf( "mode=" ) == -1 && urlLines.length > 0 ) {
-            header = header.replace( /^{{Player/, "{{Player|mode=mirrors" );
-        }
-        header = playerHeaderWithVideoAudio( header );
-
-        urlLines = [ url ].concat( urlLines.map( playerUrlValue ) ).map(function( thisUrl, index ) {
-            return playerUrlLine( thisUrl, index + 1 );
-        });
-
-        return [ header ].concat( urlLines, footerLines ).join( "\n" );
-    });
-}
-
 // replaceAndSave
 function replaceAndSave( mode, url="" ) {
     logFunc( "replaceAndSave" );
@@ -301,12 +216,12 @@ function replaceAndSave( mode, url="" ) {
 
                 if( textReplaced == text ) {
                     textReplaced = text
-                        .replace( /\|}\n\n== (Notes|Tracklist) ==/, '|}\n\n' + newPlayerTemplate( url ) + '\n\n== $1 ==' ); // No URL after wikitable, add new player
+                        .replace( /\|}\n\n== (Notes|Tracklist) ==/, '|}\n\n' + newPlayerTemplate( url, true ) + '\n\n== $1 ==' ); // No URL after wikitable, add new player
                 }
 
                 if( textReplaced == text ) {
                     textReplaced = text
-                        .replace( /(\n\n)(== (Notes|Tracklist) ==)/, '\n\n' + newPlayerTemplate( url ) + '\n\n$2' ); // No URL or wikitable, add new player before section
+                        .replace( /(\n\n)(== (Notes|Tracklist) ==)/, '\n\n' + newPlayerTemplate( url, true ) + '\n\n$2' ); // No URL or wikitable, add new player before section
                 }
             }
             break;

--- a/private/Player_URLs/funcs.js
+++ b/private/Player_URLs/funcs.js
@@ -1,0 +1,149 @@
+/* Shared helpers for private Player URL userscripts. */
+
+// Edit this list to control URL order inside {{Player|mode=mirrors}}.
+// Entries may be labels from playerSiteMatchers or URL host fragments.
+var preferredPlayerSiteOrder = [
+    "Apple Podcasts",
+    "SoundCloud",
+    "YouTube",
+    "Mixcloud"
+];
+
+var playerSiteMatchers = {
+    "Apple Podcasts": [ "podcasts.apple.com" ],
+    "SoundCloud": [ "soundcloud.com" ],
+    "YouTube": [ "youtube.com", "youtu.be" ],
+    "Mixcloud": [ "mixcloud.com" ]
+};
+
+function playerSiteOrderIndex( url ) {
+    var normalizedUrl = ( url || "" ).toLowerCase();
+
+    for( var i = 0; i < preferredPlayerSiteOrder.length; i++ ) {
+        var orderEntry = preferredPlayerSiteOrder[i],
+            matchers = playerSiteMatchers[orderEntry] || [ orderEntry ];
+
+        for( var j = 0; j < matchers.length; j++ ) {
+            if( normalizedUrl.indexOf( String( matchers[j] ).toLowerCase() ) != -1 ) {
+                return i;
+            }
+        }
+    }
+
+    return preferredPlayerSiteOrder.length;
+}
+
+function sortPlayerUrlsByPreferredOrder( urls ) {
+    return urls
+        .map(function( url, index ) {
+            return { url: url, index: index, order: playerSiteOrderIndex( url ) };
+        })
+        .sort(function( a, b ) {
+            if( a.order != b.order ) {
+                return a.order - b.order;
+            }
+            return a.index - b.index;
+        })
+        .map(function( item ) {
+            return item.url;
+        });
+}
+
+function makeEditorButton( idName, buttonText, info ) {
+    var button = document.createElement( "span" ),
+        linkWrapper = document.createElement( "a" ),
+        icon = document.createElement( "span" ),
+        label = document.createElement( "span" );
+
+    button.className = "tool oo-ui-widget oo-ui-widget-enabled oo-ui-toggleWidget oo-ui-toggleWidget-off oo-ui-buttonElement oo-ui-buttonElement-frameless oo-ui-iconElement oo-ui-toggleButtonWidget";
+    button.id = idName;
+
+    linkWrapper.className = "oo-ui-buttonElement-button";
+    linkWrapper.title = info;
+    linkWrapper.accessKey = "y";
+
+    icon.className = "fa fa-lg fa-nothing has-label";
+
+    label.className = "oo-ui-labelElement-label";
+    label.textContent = buttonText;
+
+    linkWrapper.append( icon, label );
+    button.append( linkWrapper );
+
+    return button;
+}
+
+function playerHeaderWithVideoAudio( header ) {
+    if( header.indexOf( "video=" ) == -1 ) {
+        header = header.replace( /^{{Player((?:\|mode=[^|\n}]+)?)/, "{{Player$1|video=audio" );
+    }
+    return header;
+}
+
+function playerUrlLine( url, number ) {
+    return " |" + ( url.indexOf( "=" ) == -1 ? "" : number + "=" ) + url;
+}
+
+function playerUrlValue( line ) {
+    var match = line.match( /^ \|(?:\d+=)?(https?:\/\/.+)$/ );
+    return match ? match[1] : "";
+}
+
+function newPlayerTemplate( url, forceVideoAudio ) {
+    return "{{Player" + ( forceVideoAudio ? "|video=audio" : "" ) + "\n" + playerUrlLine( url, 1 ) + "\n}}";
+}
+
+function addUrlToPlayer( text, url, forceVideoAudio ) {
+    return text.replace( /{{Player[^}]*}}/, function( player ) {
+        var lines = player.split( "\n" ),
+            header = lines.shift(),
+            urlLines = [],
+            footerLines = [];
+
+        if( forceVideoAudio ) {
+            header = playerHeaderWithVideoAudio( header );
+        }
+
+        if( lines.length == 0 ) {
+            return header.replace( /^(\{\{Player)([^}]*)\|(?:1=)?(https?:\/\/.+)\}\}$/, function( match, templateStart, options, oldUrl ) {
+                var urls = sortPlayerUrlsByPreferredOrder([ url, oldUrl ]);
+                if( options.indexOf( "mode=" ) == -1 ) {
+                    options = "|mode=mirrors" + options;
+                }
+                header = templateStart + options;
+                if( forceVideoAudio ) {
+                    header = playerHeaderWithVideoAudio( header );
+                }
+                return header + "\n" + urls.map(function( thisUrl, index ) {
+                    return playerUrlLine( thisUrl, index + 1 );
+                }).join( "\n" ) + "\n}}";
+            });
+        }
+
+        lines.forEach(function( line ) {
+            if( playerUrlValue( line ) ) {
+                urlLines.push( line );
+            } else {
+                footerLines.push( line );
+            }
+        });
+
+        if( header.indexOf( "mode=" ) == -1 && urlLines.length > 0 ) {
+            header = header.replace( /^{{Player/, "{{Player|mode=mirrors" );
+        }
+
+        urlLines = sortPlayerUrlsByPreferredOrder([ url ].concat( urlLines.map( playerUrlValue ) )).map(function( thisUrl, index ) {
+            return playerUrlLine( thisUrl, index + 1 );
+        });
+
+        return [ header ].concat( urlLines, footerLines ).join( "\n" );
+    });
+}
+
+function addApplePodcastUrlToPlayer( text, url ) {
+    return addUrlToPlayer( text, url, false );
+}
+
+function addYouTubeUrlToPlayer( text, url ) {
+    return addUrlToPlayer( text, url, true );
+}


### PR DESCRIPTION
### Motivation
- Consolidate duplicate editor and Player-manipulation helpers from the Apple Podcasts and YouTube userscripts into a single shared module to make maintenance easier. 
- Provide a configurable preferred order for player sites so new mirror URLs are inserted in a predictable order when `mode=mirrors` is used.

### Description
- Added `private/Player_URLs/funcs.js` which exposes `preferredPlayerSiteOrder`, `playerSiteMatchers`, `sortPlayerUrlsByPreferredOrder`, and shared helper functions (`makeEditorButton`, `playerHeaderWithVideoAudio`, `playerUrlLine`, `playerUrlValue`, `newPlayerTemplate`, `addUrlToPlayer`, `addApplePodcastUrlToPlayer`, `addYouTubeUrlToPlayer`).
- Default preferred order array is `"Apple Podcasts", "SoundCloud", "YouTube", "Mixcloud"` and matchers map hosts to those labels.
- Updated `private/Player_URLs/Apple_Podcasts/script.user.js` and `private/Player_URLs/YouTube/script.user.js` to `@require` the new `funcs.js`, removed the now-duplicated helper definitions from those files, and bumped the userscript `@version` entries for today (2026.07.14.*).
- Adjusted YouTube fallback insertion to call the shared `newPlayerTemplate(url, true)`/`addYouTubeUrlToPlayer` path so inserted Player templates use the shared ordering and `video=audio` when applicable.

### Testing
- Ran `node --check` on `private/Player_URLs/funcs.js`, `private/Player_URLs/YouTube/script.user.js`, and `private/Player_URLs/Apple_Podcasts/script.user.js` with no syntax errors (success).
- Executed a small Node VM smoke test of `addYouTubeUrlToPlayer` using a sample Player block to verify the inserted order is `SoundCloud` then `YouTube` then `Mixcloud` as configured (success).
- Ran `git diff --check` to verify no whitespace/conflict issues (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a567f5b8f7483208f8cc7505018f6dc)