### PR TITLE
Fix numbered Player URL insertion

### DIFF
--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.14.8
+// @version      2026.07.15.1
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_Player_URLs_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.14.1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.15.1
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes

--- a/private/Player_URLs/funcs.js
+++ b/private/Player_URLs/funcs.js
@@ -80,13 +80,23 @@ function playerHeaderWithVideoAudio( header ) {
     return header;
 }
 
-function playerUrlLine( url, number ) {
-    return " |" + ( url.indexOf( "=" ) == -1 ? "" : number + "=" ) + url;
+function playerUrlLine( url, number, forceNumbered ) {
+    return " |" + ( forceNumbered || url.indexOf( "=" ) != -1 ? number + "=" : "" ) + url;
 }
 
 function playerUrlValue( line ) {
     var match = line.match( /^ \|(?:\d+=)?(https?:\/\/.+)$/ );
     return match ? match[1] : "";
+}
+
+function playerUrlLineIsNumbered( line ) {
+    return /^ \|\d+=https?:\/\//.test( line );
+}
+
+function playerUrlsNeedNumberedLines( urls, urlLines ) {
+    return urls.some(function( thisUrl ) {
+        return thisUrl.indexOf( "=" ) != -1;
+    }) || ( urlLines || [] ).some( playerUrlLineIsNumbered );
 }
 
 function newPlayerTemplate( url, forceVideoAudio ) {
@@ -106,7 +116,8 @@ function addUrlToPlayer( text, url, forceVideoAudio ) {
 
         if( lines.length == 0 ) {
             return header.replace( /^(\{\{Player)([^}]*)\|(?:1=)?(https?:\/\/.+)\}\}$/, function( match, templateStart, options, oldUrl ) {
-                var urls = sortPlayerUrlsByPreferredOrder([ url, oldUrl ]);
+                var urls = sortPlayerUrlsByPreferredOrder([ url, oldUrl ]),
+                    forceNumbered = playerUrlsNeedNumberedLines( urls, [] );
                 if( options.indexOf( "mode=" ) == -1 ) {
                     options = "|mode=mirrors" + options;
                 }
@@ -115,7 +126,7 @@ function addUrlToPlayer( text, url, forceVideoAudio ) {
                     header = playerHeaderWithVideoAudio( header );
                 }
                 return header + "\n" + urls.map(function( thisUrl, index ) {
-                    return playerUrlLine( thisUrl, index + 1 );
+                    return playerUrlLine( thisUrl, index + 1, forceNumbered );
                 }).join( "\n" ) + "\n}}";
             });
         }
@@ -132,8 +143,11 @@ function addUrlToPlayer( text, url, forceVideoAudio ) {
             header = header.replace( /^{{Player/, "{{Player|mode=mirrors" );
         }
 
-        urlLines = sortPlayerUrlsByPreferredOrder([ url ].concat( urlLines.map( playerUrlValue ) )).map(function( thisUrl, index ) {
-            return playerUrlLine( thisUrl, index + 1 );
+        var urls = sortPlayerUrlsByPreferredOrder([ url ].concat( urlLines.map( playerUrlValue ) )),
+            forceNumbered = playerUrlsNeedNumberedLines( urls, urlLines );
+
+        urlLines = urls.map(function( thisUrl, index ) {
+            return playerUrlLine( thisUrl, index + 1, forceNumbered );
         });
 
         return [ header ].concat( urlLines, footerLines ).join( "\n" );


### PR DESCRIPTION
### Motivation
- Ensure `{{Player}}` URL lines preserve or convert to numbered `|X=` form when inserting YouTube URLs if any existing lines are numbered or any URL contains `=`.

### Description
- Add a `forceNumbered` flag to `playerUrlLine` so lines can be emitted as `|N=` unconditionally when needed (`playerUrlLine(url, number, forceNumbered)`).
- Add `playerUrlLineIsNumbered` and `playerUrlsNeedNumberedLines` to detect when numbering must be preserved or enforced for all URL lines.
- Use the detection in both the single-line and multi-line `{{Player}}` update paths so inserted/sorted URLs are renumbered consistently and existing numbered style is preserved.
- Bump the YouTube userscript `@version` and the `funcs.js` cache-buster to `2026.07.15.1`.

### Testing
- Ran a `node` regression snippet that exercises the Apple Podcasts/SoundCloud/YouTube/Mixcloud insertion case and it succeeded (`ok`).
- Ran `node --check private/Player_URLs/funcs.js` and `node --check private/Player_URLs/YouTube/script.user.js` and both checks passed.
- Ran `git diff --check` to validate whitespace and diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a574421ed588320a38cf79a266f6cb4)