### PR TITLE
Add YouTube `addAsTitle` option and support `|t=` titles in Player helpers

### DIFF
--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,19 +1,22 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.16.1
+// @version      2026.07.16.2
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_Player_URLs_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.15.5
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.16.1
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes
 // @grant        unsafeWindow
 // @run-at       document-end
 // ==/UserScript==
+
+// Add the YouTube URL with this title text; to unset use =""
+const addAsTitle = "";
 
 // Regex string for matching episode numbers in MixesDB page titles
 var epId_regex = /^.*\bTransitions (\d+)\b.*$/;
@@ -193,22 +196,22 @@ function replaceAndSave( mode, url="" ) {
                 $("#autoYTurls a").remove();
                 skipSave = true;
             } else {
-                textReplaced = addYouTubeUrlToPlayer( text, url );
+                textReplaced = addYouTubeUrlToPlayer( text, url, addAsTitle );
 
                 if( textReplaced == text ) {
                     textReplaced = text
-                        .replace( /\|}\n\n== (Notes|Tracklist) ==/, '|}\n\n' + newPlayerTemplate( url, true ) + '\n\n== $1 ==' ); // No URL after wikitable, add new player
+                        .replace( /\|}\n\n== (Notes|Tracklist) ==/, '|}\n\n' + newPlayerTemplate( url, true, addAsTitle ) + '\n\n== $1 ==' ); // No URL after wikitable, add new player
                 }
 
                 if( textReplaced == text ) {
                     textReplaced = text
-                        .replace( /(\n\n)(== (Notes|Tracklist) ==)/, '\n\n' + newPlayerTemplate( url, true ) + '\n\n$2' ); // No URL or wikitable, add new player before section
+                        .replace( /(\n\n)(== (Notes|Tracklist) ==)/, '\n\n' + newPlayerTemplate( url, true, addAsTitle ) + '\n\n$2' ); // No URL or wikitable, add new player before section
                 }
             }
             break;
     }
 
-    if( text.match(/{{Player.+\|t\d+=.+}}/) ) {
+    if( !addAsTitle && text.match(/{{Player.+\|t\d*=.+}}/) ) {
         warning += "t parameters found. Please renumber!";
     }
 

--- a/private/Player_URLs/funcs.js
+++ b/private/Player_URLs/funcs.js
@@ -35,20 +35,25 @@ function playerSiteOrderIndex( url ) {
     return preferredPlayerSiteOrder.length;
 }
 
-function sortPlayerUrlsByPreferredOrder( urls ) {
-    return urls
-        .map(function( url, index ) {
-            return { url: url, index: index, order: playerSiteOrderIndex( url ) };
+function sortPlayerUrlItemsByPreferredOrder( items ) {
+    return items
+        .map(function( item, index ) {
+            return { url: item.url, title: item.title || "", index: index, order: playerSiteOrderIndex( item.url ) };
         })
         .sort(function( a, b ) {
             if( a.order != b.order ) {
                 return a.order - b.order;
             }
             return a.index - b.index;
-        })
-        .map(function( item ) {
-            return item.url;
         });
+}
+
+function sortPlayerUrlsByPreferredOrder( urls ) {
+    return sortPlayerUrlItemsByPreferredOrder( urls.map(function( url ) {
+        return { url: url };
+    })).map(function( item ) {
+        return item.url;
+    });
 }
 
 function makeEditorButton( idName, buttonText, info ) {
@@ -82,13 +87,25 @@ function playerHeaderWithVideoAudio( header ) {
     return header;
 }
 
-function playerUrlLine( url, number, forceNumbered ) {
-    return " |" + ( forceNumbered || url.indexOf( "=" ) != -1 ? number + "=" : "" ) + url;
+function playerTitleParam( title, number ) {
+    if( !title ) {
+        return "";
+    }
+    return "|t" + ( number > 1 ? number : "" ) + "=" + title;
+}
+
+function playerUrlLine( url, number, forceNumbered, title ) {
+    return " |" + ( forceNumbered || url.indexOf( "=" ) != -1 ? number + "=" : "" ) + url + playerTitleParam( title, number );
+}
+
+function playerUrlParts( line ) {
+    var match = line.match( /^ \|(?:\d+=)?(https?:\/\/.*?)(?:\|t\d*=(.*))?$/ );
+    return match ? { url: match[1], title: match[2] || "" } : null;
 }
 
 function playerUrlValue( line ) {
-    var match = line.match( /^ \|(?:\d+=)?(https?:\/\/.+)$/ );
-    return match ? match[1] : "";
+    var parts = playerUrlParts( line );
+    return parts ? parts.url : "";
 }
 
 function playerUrlLineIsNumbered( line ) {
@@ -101,11 +118,24 @@ function playerUrlsNeedNumberedLines( urls, urlLines ) {
     }) || ( urlLines || [] ).some( playerUrlLineIsNumbered );
 }
 
-function newPlayerTemplate( url, forceVideoAudio ) {
-    return "{{Player" + ( forceVideoAudio ? "|video=audio" : "" ) + "\n" + playerUrlLine( url, 1 ) + "\n}}";
+function newPlayerTemplate( url, forceVideoAudio, title ) {
+    return "{{Player" + ( forceVideoAudio ? "|video=audio" : "" ) + "\n" + playerUrlLine( url, 1, false, title ) + "\n}}";
 }
 
-function addUrlToPlayer( text, url, forceVideoAudio ) {
+function nextPlayerTitleNumber( urlLines ) {
+    var highestNumber = 0;
+
+    urlLines.forEach(function( line ) {
+        var match = line.match( /\|t(\d*)=/ );
+        if( match ) {
+            highestNumber = Math.max( highestNumber, match[1] ? parseInt( match[1], 10 ) : 1 );
+        }
+    });
+
+    return highestNumber + 1;
+}
+
+function addUrlToPlayer( text, url, forceVideoAudio, title ) {
     return text.replace( /{{Player[^}]*}}/, function( player ) {
         var lines = player.split( "\n" ),
             header = lines.shift(),
@@ -118,7 +148,7 @@ function addUrlToPlayer( text, url, forceVideoAudio ) {
 
         if( lines.length == 0 ) {
             return header.replace( /^(\{\{Player)([^}]*)\|(?:1=)?(https?:\/\/.+)\}\}$/, function( match, templateStart, options, oldUrl ) {
-                var urls = sortPlayerUrlsByPreferredOrder([ url, oldUrl ]),
+                var urls = title ? [ oldUrl, url ] : sortPlayerUrlsByPreferredOrder([ url, oldUrl ]),
                     forceNumbered = playerUrlsNeedNumberedLines( urls, [] );
                 if( options.indexOf( "mode=" ) == -1 ) {
                     options = "|mode=mirrors" + options;
@@ -128,7 +158,7 @@ function addUrlToPlayer( text, url, forceVideoAudio ) {
                     header = playerHeaderWithVideoAudio( header );
                 }
                 return header + "\n" + urls.map(function( thisUrl, index ) {
-                    return playerUrlLine( thisUrl, index + 1, forceNumbered );
+                    return playerUrlLine( thisUrl, index + 1, forceNumbered, title && thisUrl == url ? title : "" );
                 }).join( "\n" ) + "\n}}";
             });
         }
@@ -145,12 +175,18 @@ function addUrlToPlayer( text, url, forceVideoAudio ) {
             header = header.replace( /^{{Player/, "{{Player|mode=mirrors" );
         }
 
-        var urls = sortPlayerUrlsByPreferredOrder([ url ].concat( urlLines.map( playerUrlValue ) )),
-            forceNumbered = playerUrlsNeedNumberedLines( urls, urlLines );
+        var urls, forceNumbered;
 
-        urlLines = urls.map(function( thisUrl, index ) {
-            return playerUrlLine( thisUrl, index + 1, forceNumbered );
-        });
+        if( title ) {
+            urlLines.push( playerUrlLine( url, nextPlayerTitleNumber( urlLines ), false, title ) );
+        } else {
+            urls = sortPlayerUrlItemsByPreferredOrder([ { url: url } ].concat( urlLines.map( playerUrlParts ) ));
+            forceNumbered = playerUrlsNeedNumberedLines( urls.map(function( item ) { return item.url; }), urlLines );
+
+            urlLines = urls.map(function( item, index ) {
+                return playerUrlLine( item.url, index + 1, forceNumbered, item.title );
+            });
+        }
 
         return [ header ].concat( urlLines, footerLines ).join( "\n" );
     });
@@ -160,6 +196,6 @@ function addApplePodcastUrlToPlayer( text, url ) {
     return addUrlToPlayer( text, url, false );
 }
 
-function addYouTubeUrlToPlayer( text, url ) {
-    return addUrlToPlayer( text, url, true );
+function addYouTubeUrlToPlayer( text, url, title ) {
+    return addUrlToPlayer( text, url, true, title );
 }


### PR DESCRIPTION
### Motivation
- Allow inserting a YouTube URL with a provided title label into existing `{{Player}}` templates or into a newly created player when desired by adding a single top-level option. 
- Preserve existing behavior (preferred-site ordering and `t`-parameter warnings) when this title option is not used.

### Description
- Add `const addAsTitle = "";` at the top of the YouTube userscript with a comment that `=""` unsets the behavior, and bump the userscript `@version` and the `funcs.js` cache-bust query. 
- Pass `addAsTitle` through to `addYouTubeUrlToPlayer()` and to `newPlayerTemplate()` so the insertion code can decide titled vs untitled flows. 
- Extend shared player helpers in `private/Player_URLs/funcs.js` to parse and preserve existing `|t=`/`|tN=` title parameters, render `|t=` for single-row new templates, compute the next `t` number with `nextPlayerTitleNumber()`, and append a titled YouTube row as the last row when a title is provided (while untitled insertions still use preferred-site ordering). 
- Only show the existing "t parameters found. Please renumber!" warning when `addAsTitle` is unset so the titled-insert flow can add numbered `t` parameters safely.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and it succeeded. 
- Ran Node VM assertions that validate adding a titled YouTube URL to an existing multi-row `{{Player}}` produces the expected `|tN=` appended row and that `newPlayerTemplate()` produces a single-row template with a bare `|t=` when a title is provided; both assertions passed. 
- Ran additional Node checks for ordering behavior with and without titles to ensure titled insertions append while untitled insertions keep preferred ordering; these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58a3e311f08320b4923884751f272c)