### PR TITLE
Fill missing Player URL titles with `Complete` and force numbered `t` params

### DIFF
--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.16.2
+// @version      2026.07.16.3
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_Player_URLs_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.16.1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.16.2
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes

--- a/private/Player_URLs/funcs.js
+++ b/private/Player_URLs/funcs.js
@@ -87,20 +87,20 @@ function playerHeaderWithVideoAudio( header ) {
     return header;
 }
 
-function playerTitleParam( title, number ) {
+function playerTitleParam( title, number, forceNumberedTitle ) {
     if( !title ) {
         return "";
     }
-    return "|t" + ( number > 1 ? number : "" ) + "=" + title;
+    return "|t" + ( forceNumberedTitle || number > 1 ? number : "" ) + "=" + title;
 }
 
-function playerUrlLine( url, number, forceNumbered, title ) {
-    return " |" + ( forceNumbered || url.indexOf( "=" ) != -1 ? number + "=" : "" ) + url + playerTitleParam( title, number );
+function playerUrlLine( url, number, forceNumbered, title, forceNumberedTitle ) {
+    return " |" + ( forceNumbered || url.indexOf( "=" ) != -1 ? number + "=" : "" ) + url + playerTitleParam( title, number, forceNumberedTitle );
 }
 
 function playerUrlParts( line ) {
-    var match = line.match( /^ \|(?:\d+=)?(https?:\/\/.*?)(?:\|t\d*=(.*))?$/ );
-    return match ? { url: match[1], title: match[2] || "" } : null;
+    var match = line.match( /^ \|(?:\d+=)?(https?:\/\/.*?)(?:\|t(\d*)=(.*))?$/ );
+    return match ? { url: match[1], title: match[3] || "", hasTitle: typeof match[2] != "undefined" } : null;
 }
 
 function playerUrlValue( line ) {
@@ -120,6 +120,24 @@ function playerUrlsNeedNumberedLines( urls, urlLines ) {
 
 function newPlayerTemplate( url, forceVideoAudio, title ) {
     return "{{Player" + ( forceVideoAudio ? "|video=audio" : "" ) + "\n" + playerUrlLine( url, 1, false, title ) + "\n}}";
+}
+
+function playerUrlItemsNeedTitles( items ) {
+    return items.some(function( item ) {
+        return item.title || item.hasTitle;
+    });
+}
+
+function titleMissingPlayerUrlItemsAsComplete( items ) {
+    if( playerUrlItemsNeedTitles( items ) ) {
+        items.forEach(function( item ) {
+            if( !item.title && !item.hasTitle ) {
+                item.title = "Complete";
+            }
+        });
+    }
+
+    return items;
 }
 
 function nextPlayerTitleNumber( urlLines ) {
@@ -148,8 +166,11 @@ function addUrlToPlayer( text, url, forceVideoAudio, title ) {
 
         if( lines.length == 0 ) {
             return header.replace( /^(\{\{Player)([^}]*)\|(?:1=)?(https?:\/\/.+)\}\}$/, function( match, templateStart, options, oldUrl ) {
-                var urls = title ? [ oldUrl, url ] : sortPlayerUrlsByPreferredOrder([ url, oldUrl ]),
+                var items = title ? [ { url: oldUrl }, { url: url, title: title, hasTitle: true } ] : sortPlayerUrlItemsByPreferredOrder([ { url: url }, { url: oldUrl } ]),
+                    forceTitles = playerUrlItemsNeedTitles( items ),
+                    urls = items.map(function( item ) { return item.url; }),
                     forceNumbered = playerUrlsNeedNumberedLines( urls, [] );
+                titleMissingPlayerUrlItemsAsComplete( items );
                 if( options.indexOf( "mode=" ) == -1 ) {
                     options = "|mode=mirrors" + options;
                 }
@@ -157,8 +178,8 @@ function addUrlToPlayer( text, url, forceVideoAudio, title ) {
                 if( forceVideoAudio ) {
                     header = playerHeaderWithVideoAudio( header );
                 }
-                return header + "\n" + urls.map(function( thisUrl, index ) {
-                    return playerUrlLine( thisUrl, index + 1, forceNumbered, title && thisUrl == url ? title : "" );
+                return header + "\n" + items.map(function( item, index ) {
+                    return playerUrlLine( item.url, index + 1, forceNumbered, item.title, forceTitles );
                 }).join( "\n" ) + "\n}}";
             });
         }
@@ -178,13 +199,21 @@ function addUrlToPlayer( text, url, forceVideoAudio, title ) {
         var urls, forceNumbered;
 
         if( title ) {
-            urlLines.push( playerUrlLine( url, nextPlayerTitleNumber( urlLines ), false, title ) );
-        } else {
-            urls = sortPlayerUrlItemsByPreferredOrder([ { url: url } ].concat( urlLines.map( playerUrlParts ) ));
+            urls = urlLines.map( playerUrlParts );
+            urls.push( { url: url, title: title, hasTitle: true } );
+            titleMissingPlayerUrlItemsAsComplete( urls );
             forceNumbered = playerUrlsNeedNumberedLines( urls.map(function( item ) { return item.url; }), urlLines );
 
             urlLines = urls.map(function( item, index ) {
-                return playerUrlLine( item.url, index + 1, forceNumbered, item.title );
+                return playerUrlLine( item.url, index + 1, forceNumbered, item.title, true );
+            });
+        } else {
+            urls = sortPlayerUrlItemsByPreferredOrder([ { url: url } ].concat( urlLines.map( playerUrlParts ) ));
+            titleMissingPlayerUrlItemsAsComplete( urls );
+            forceNumbered = playerUrlsNeedNumberedLines( urls.map(function( item ) { return item.url; }), urlLines );
+
+            urlLines = urls.map(function( item, index ) {
+                return playerUrlLine( item.url, index + 1, forceNumbered, item.title, playerUrlItemsNeedTitles( urls ) );
             });
         }
 


### PR DESCRIPTION
### Motivation
- Existing `{{Player}}` templates without `t` parameters should get a default title when a titled URL is added so all entries have consistent `tN=` labels.
- When adding a titled YouTube URL to an untitled player block, existing rows must be rewritten to use numbered `t1`, `t2`, ... parameters to avoid ambiguous `|t=` usage.

### Description
- Added a `forceNumberedTitle` parameter to `playerTitleParam` and propagated it through `playerUrlLine` to allow forcing numbered `t` parameters (`t1`, `t2`, etc.).
- Extended `playerUrlParts` to detect existing title numbers and return `{ url, title, hasTitle }` so presence of `t` params can be observed.
- Implemented `playerUrlItemsNeedTitles` and `titleMissingPlayerUrlItemsAsComplete` helpers and used them in `addUrlToPlayer` to fill missing titles with `"Complete"` whenever any item has a title, and to force numbered title parameters when inserting a titled URL.
- Bumped the YouTube userscript version and updated the helper cachebuster reference in `private/Player_URLs/YouTube/script.user.js` to reflect the changes (`2026.07.16.3` and `funcs.js?v-2026.07.16.2`).

### Testing
- Ran an inline `node` regression test that exercises adding a titled YouTube URL to an existing untitled `{{Player}}` block and it produced the expected output (test passed).
- Performed syntax checks with `node --check private/Player_URLs/funcs.js` and `node --check private/Player_URLs/YouTube/script.user.js` (both passed).
- Ran `git diff --check` to ensure no trailing whitespace or index issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58a7b0f724832098adfd068e9b219b)