### PR TITLE
Use multi mode for titled YouTube player URLs

### DIFF
--- a/private/Player_URLs/YouTube/script.user.js
+++ b/private/Player_URLs/YouTube/script.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name         YouTube Player URLs (private)
-// @version      2026.07.16.3
+// @version      2026.07.16.4
 // @description  Add YouTube player URLs from array to mix pages when episode numbers match the mix page title
 // @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/YouTube/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_Player_URLs_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.16.2
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.16.3
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes

--- a/private/Player_URLs/funcs.js
+++ b/private/Player_URLs/funcs.js
@@ -80,6 +80,14 @@ function makeEditorButton( idName, buttonText, info ) {
     return button;
 }
 
+function playerHeaderWithMode( header, mode ) {
+    if( header.indexOf( "mode=" ) == -1 ) {
+        return header.replace( /^{{Player/, "{{Player|mode=" + mode );
+    }
+
+    return header.replace( /\|mode=[^|\n}]+/, "|mode=" + mode );
+}
+
 function playerHeaderWithVideoAudio( header ) {
     if( header.indexOf( "video=" ) == -1 ) {
         header = header.replace( /^{{Player((?:\|mode=[^|\n}]+)?)/, "{{Player$1|video=audio" );
@@ -171,10 +179,14 @@ function addUrlToPlayer( text, url, forceVideoAudio, title ) {
                     urls = items.map(function( item ) { return item.url; }),
                     forceNumbered = playerUrlsNeedNumberedLines( urls, [] );
                 titleMissingPlayerUrlItemsAsComplete( items );
-                if( options.indexOf( "mode=" ) == -1 ) {
-                    options = "|mode=mirrors" + options;
+                if( title ) {
+                    header = playerHeaderWithMode( templateStart + options, "multi" );
+                } else {
+                    if( options.indexOf( "mode=" ) == -1 ) {
+                        options = "|mode=mirrors" + options;
+                    }
+                    header = templateStart + options;
                 }
-                header = templateStart + options;
                 if( forceVideoAudio ) {
                     header = playerHeaderWithVideoAudio( header );
                 }
@@ -192,8 +204,10 @@ function addUrlToPlayer( text, url, forceVideoAudio, title ) {
             }
         });
 
-        if( header.indexOf( "mode=" ) == -1 && urlLines.length > 0 ) {
-            header = header.replace( /^{{Player/, "{{Player|mode=mirrors" );
+        if( title && urlLines.length > 0 ) {
+            header = playerHeaderWithMode( header, "multi" );
+        } else if( header.indexOf( "mode=" ) == -1 && urlLines.length > 0 ) {
+            header = playerHeaderWithMode( header, "mirrors" );
         }
 
         var urls, forceNumbered;


### PR DESCRIPTION
### Motivation
- Ensure that when adding a YouTube URL with a title (`addAsTitle`), existing `{{Player}}` templates are switched to `|mode=multi` so titles are preserved and numbered correctly. 
- Preserve the current behavior of untitled URL additions using `|mode=mirrors` to avoid changing existing layout for non-titled inserts. 
- Bump the private YouTube userscript and the `funcs.js` cache-buster to today's date as required for userscript updates.

### Description
- Added `playerHeaderWithMode(header, mode)` in `private/Player_URLs/funcs.js` to insert or replace a `mode=` parameter on `{{Player}}` headers. 
- Updated `addUrlToPlayer` in `private/Player_URLs/funcs.js` to call `playerHeaderWithMode(..., "multi")` when a `title` is provided so existing templates become `|mode=multi`, and to use `|mode=mirrors` for untitled additions. 
- Bumped `@version` in `private/Player_URLs/YouTube/script.user.js` to `2026.07.16.4` and updated the `funcs.js` cache-buster query to `?v-2026.07.16.3`.

### Testing
- Ran a Node VM smoke test that exercises titled and untitled `addYouTubeUrlToPlayer` insertion and it passed (`ok`) verifying `|mode=multi` for titled inserts and `|mode=mirrors` for untitled inserts. 
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58a9b2d04883208c6bb416c177930b)