### PR TITLE
Fix RA event artwork overlap

### DIFF
--- a/RA/script.css
+++ b/RA/script.css
@@ -1,11 +1,19 @@
+.mdb-ra-artwork-wrapper,
+img.mdb-ra-artwork-processed {
+    display: block;
+}
+
 .mdb-ra-artwork-info {
     background-color: #444;
+    clear: both;
     display: flex;
     font-size: 12px;
     line-height: 20px;
     min-height: 20px;
+    position: relative;
     width: 100%;
     font-family: sans-serif;
+    z-index: 1;
 }
 
 .mdb-ra-artwork-input,

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.16.1
+// @version      2026.07.16.2
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -37,7 +37,7 @@ https://de.ra.co/events/2232716
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 21,
+var cacheVersion = 22,
     scriptName = "RA";
 
 loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
@@ -382,7 +382,7 @@ function getRaArtworkSource( img ) {
 }
 
 function getRaEventArtworkWrapper( img ) {
-    return img.parent("[class*='FullWidthStyle']");
+    return img.parent("[class*='FullWidthStyle']").addClass("mdb-ra-artwork-wrapper");
 }
 
 function isRaEventArtwork( img ) {


### PR DESCRIPTION
### Motivation
- Prevent multiple event images on RA event pages from overlapping the artwork URL/info wrapper so artwork and its info are displayed cleanly.
- Ensure the userscript and stylesheet cache are updated so the CSS fix is delivered to users.

### Description
- Bumped the userscript header `@version` to `2026.07.16.2` and incremented `cacheVersion` from `21` to `22` so updated CSS is fetched.
- Mark RA event artwork containers by adding `mdb-ra-artwork-wrapper` via `getRaEventArtworkWrapper()` so they can be targeted reliably from CSS.
- Added CSS rules to force `.mdb-ra-artwork-wrapper` and `img.mdb-ra-artwork-processed` to `display: block`, and updated `.mdb-ra-artwork-info` with `clear: both`, `position: relative`, and `z-index: 1` to stop overlap.

### Testing
- Ran `node --check RA/script.user.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e643f1f08320aac882117f678fb0)