### PR TITLE
Fix Tracklist Merger numeric artist cue handling

### DIFF
--- a/Tracklist_Merger/script.user.js
+++ b/Tracklist_Merger/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tracklist Merger (Beta)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.05.29.4
+// @version      2026.07.18.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -1249,6 +1249,37 @@ function normalizeTracklistCueFormat(tl_arr, targetFormat, options) {
     return tl_arr;
 }
 
+
+/*
+ * getUnknownCueForFormat
+ * Return an explicit unknown cue placeholder in the active cue style.
+ */
+function getUnknownCueForFormat(format) {
+    if( format && format.hasColon ) {
+        return String("?").repeat(format.minDigits) + ":" + String("?").repeat(format.secDigits);
+    }
+
+    return String("?").repeat(format && format.cueDigits ? format.cueDigits : 2);
+}
+
+/*
+ * ensureExplicitTrackCues
+ * The Tracklist Editor API treats unbracketed leading numbers as cue times.
+ * Add an explicit unknown cue to every merged track without a cue so artist
+ * names like "01100110 - Stumbling Blocks Of Humanity" remain track text.
+ */
+function ensureExplicitTrackCues(tl_arr, format) {
+    var unknownCue = getUnknownCueForFormat(format);
+
+    tl_arr.forEach(function(item){
+        if( item.type === "track" && (!item.cue || String(item.cue).trim() === "") ) {
+            item.cue = unknownCue;
+        }
+    });
+
+    return tl_arr;
+}
+
 /*
  * run_merge
  */
@@ -1287,6 +1318,11 @@ function run_merge( showDebug=false ) {
 
     // Keep merged cues in original format.
     normalizeTracklistCueFormat(tl_merged_arr, originalCueFormat, candidateCueNormalizationOptions);
+
+    // Add explicit unknown cues before sending the text through the Tracklist
+    // Editor API. Otherwise unbracketed numeric artist names may be mistaken
+    // for cue times by the API.
+    ensureExplicitTrackCues(tl_merged_arr, originalCueFormat);
 
     // If the merged list uses MM:SS cues, normalize unknown/missing cues
     // to "X:??" where X is the last known minute prefix.


### PR DESCRIPTION
### Motivation
- Prevent artist names that begin with numbers (e.g. `01100110 - Stumbling Blocks Of Humanity`) from being misinterpreted as cue times by the Tracklist Editor API.
- The Tracklist Editor API can treat unbracketed leading numbers as cue times, so merged output must make unknown cues explicit.
- Also bump the userscript version to today's date to follow the repository convention.

### Description
- Bump `Tracklist_Merger/script.user.js` version to `2026.07.18.1`.
- Add `getUnknownCueForFormat(format)` to produce an unknown-cue placeholder that matches the active cue style (colon vs digits).
- Add `ensureExplicitTrackCues(tl_arr, format)` which injects explicit unknown cues into merged tracks that lack a cue.
- Call `ensureExplicitTrackCues` on the merged tracklist before passing text through the Tracklist Editor API so numeric artist names remain as track text.

### Testing
- Ran `node --check Tracklist_Merger/script.user.js` and it completed without syntax errors.
- Executed a Node VM smoke test that imported `ensureExplicitTrackCues` and verified it adds `???` for a 3-digit cue format and `??` for the default format, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b68fc1388832092c2d3da5983b10d)