### PR TITLE
Add IA MIX episodes importer

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,0 +1,390 @@
+// ==UserScript==
+// @name         IA MIX (private)
+// @author       User:Martin@MixesDB (Subfader@GitHub)
+// @version      2026.07.20.1
+// @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
+// @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
+// @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
+// @updateURL    https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/script.user.js
+// @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/script.user.js
+// @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
+// @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.1
+// @include      https://inverted-audio.com/mix*
+// @include      https://www.mixesdb.com/w/index.php*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
+// @noframes
+// @grant        unsafeWindow
+// @run-at       document-end
+// ==/UserScript==
+
+var cacheVersion = 1,
+    scriptName = "IA_MIX";
+
+loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cacheVersion );
+
+(function () {
+    'use strict';
+
+    const importer = window.MixesDBEpisodesImporter;
+    if (!importer) {
+        console.error('MixesDBEpisodesImporter dependency is not available.');
+        return;
+    }
+
+    const sourceHost = 'inverted-audio.com';
+    const mixesdbHost = 'www.mixesdb.com';
+    const config = {
+        categoryTitle: 'Category:IA_MIX',
+        titleEpisodePattern: /IA MIX\s+(\d{1,4})\b/i,
+        showCategory: 'IA MIX',
+        storageKey: 'mdbIaMixRemoveExistingEpisodes',
+        visitedLinksStorageKey: 'mdbIaMixVisitedEpisodeLinks',
+        tleApiType: 'standard',
+        selectors: {
+            listContainer: '#post-load',
+            episodeWrapper: '#post-load article.type-mix, article.type-mix',
+            episodeHeading: '.entry-title',
+            episodeLink: '.entry-title a[href], .entry-img a[href]',
+            description: '.entry-content',
+            nextPage: 'nav.posts-navigation a.next[href]',
+        },
+        classNames: {
+            link: 'mdb-ia-mix-link',
+            closeButton: 'mdb-ia-mix-close-button',
+            toggle: 'mdb-ia-mix-remove-existing-toggle',
+            hidden: 'mdb-ia-mix-existing-episode-hidden',
+            copiedWrapper: 'mdb-ia-mix-copied-wrapper',
+            autoLoadMoreWaiter: 'mdb-ia-mix-auto-load-more-waiter',
+        },
+        autoLoadMoreDelay: 700,
+    };
+
+    let existingEpisodes = new Set();
+    let visitedEpisodeLinks = new Set();
+    let removeExistingEpisodes = false;
+    let autoLoadMoreTimer = null;
+    let autoLoadMoreInProgress = false;
+    let lastAutoLoadVisibleMissingCount = 0;
+
+    function logStep(step, details = '') {
+        importer.logValue(`IA MIX importer: ${step}`, typeof details === 'object' ? JSON.stringify(details) : details);
+    }
+
+    function loadVisitedEpisodeLinks() {
+        try {
+            visitedEpisodeLinks = new Set(JSON.parse(localStorage.getItem(config.visitedLinksStorageKey) || '[]'));
+        } catch (error) {
+            visitedEpisodeLinks = new Set();
+        }
+    }
+
+    function saveVisitedEpisodeLinks() {
+        localStorage.setItem(config.visitedLinksStorageKey, JSON.stringify(Array.from(visitedEpisodeLinks)));
+    }
+
+    function setLinkVisitedState(link) {
+        link.classList.toggle('is-visited', visitedEpisodeLinks.has(link.dataset.episodeNumber));
+    }
+
+    function markLinkVisited(link) {
+        visitedEpisodeLinks.add(link.dataset.episodeNumber);
+        saveVisitedEpisodeLinks();
+        setLinkVisitedState(link);
+    }
+
+    function parseEpisodeTitle(title) {
+        const match = String(title || '').match(/IA MIX\s+(\d{1,4})\s+(.+)/i);
+        if (!match) return null;
+
+        return {
+            episodeNumber: Number(match[1]),
+            artist: match[2].trim(),
+        };
+    }
+
+    function normalizeDate(dateText) {
+        const isoMatch = String(dateText || '').match(/\b(\d{4})-(\d{2})-(\d{2})\b/);
+        if (isoMatch) return isoMatch[0];
+
+        const longDateMatch = String(dateText || '').match(/\b([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})\b/);
+        if (!longDateMatch) return '';
+
+        const month = importer.getMonthNumber(longDateMatch[1]);
+        if (!month) return '';
+
+        return `${longDateMatch[3]}-${month}-${String(longDateMatch[2]).padStart(2, '0')}`;
+    }
+
+    function extractDateFromDocument(doc) {
+        const candidates = [
+            doc.querySelector('time[datetime]')?.getAttribute('datetime'),
+            doc.querySelector('meta[property="article:published_time"]')?.content,
+            doc.querySelector('meta[name="date"]')?.content,
+            doc.querySelector('.entry-date, .posted-on, .entry-meta')?.textContent,
+        ];
+
+        return candidates.map(normalizeDate).find(Boolean) || '';
+    }
+
+    async function fetchEpisodeDetails(episodeUrl) {
+        const response = await fetch(episodeUrl, { credentials: 'same-origin' });
+        if (!response.ok) throw new Error(`Episode page responded with ${response.status}`);
+
+        const html = await response.text();
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        return {
+            date: extractDateFromDocument(doc),
+            playerUrl: doc.querySelector('iframe[src*="soundcloud.com"], iframe[src*="mixcloud.com"], iframe[src*="hearthis.at"], audio[src], audio source[src]')?.src || '',
+        };
+    }
+
+    function buildMixesdbTitle(episode) {
+        const prefix = episode.date ? `${episode.date} - ` : '';
+        return `${prefix}${episode.artist} - IA MIX ${importer.padNumber(episode.episodeNumber)}`;
+    }
+
+    function buildEpisodePageText(episode, playerUrl = '') {
+        return importer.buildMixPageText({
+            year: episode.date ? episode.date.slice(0, 4) : '',
+            artist: episode.artist,
+            showCategory: config.showCategory,
+            tracklistResult: { text: '<list>\n\n</list>', status: 'none' },
+            playerUrl,
+        });
+    }
+
+    function setCreateLinkHref(link, episode, episodeUrl, playerUrl = '') {
+        link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, playerUrl));
+    }
+
+    async function updateMixesdbLink(link, episode, wrapper) {
+        const episodeUrl = link.dataset.episodeUrl || location.href;
+        const isExisting = existingEpisodes.has(episode.episodeNumber);
+
+        link.className = `${config.classNames.link} ${isExisting ? 'is-existing' : 'is-pending'}`;
+        link.textContent = isExisting ? 'See on MixesDB' : `Checking IA MIX ${importer.padNumber(episode.episodeNumber)}`;
+        setLinkVisitedState(link);
+
+        try {
+            const details = await fetchEpisodeDetails(episodeUrl);
+            episode.date = details.date;
+            if (isExisting) {
+                link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl);
+            } else {
+                setCreateLinkHref(link, episode, episodeUrl, details.playerUrl);
+            }
+        } catch (error) {
+            logStep('failed to fetch episode details', { episodeUrl, error: error.message || error });
+            if (isExisting) {
+                link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl);
+            } else {
+                setCreateLinkHref(link, episode, episodeUrl);
+            }
+        }
+
+        link.className = `${config.classNames.link} ${isExisting ? 'is-existing' : 'is-missing'}`;
+        link.textContent = isExisting ? 'See on MixesDB' : 'Copy to MixesDB';
+        link.title = buildMixesdbTitle(episode);
+        setLinkVisitedState(link);
+    }
+
+    function setEpisodeVisibility(wrapper, episode) {
+        wrapper.classList.toggle(config.classNames.hidden, removeExistingEpisodes && existingEpisodes.has(episode.episodeNumber));
+    }
+
+    function updateEpisodeVisibility() {
+        document.querySelectorAll(`${config.selectors.episodeWrapper}[data-mdb-episode-number]`).forEach(wrapper => {
+            setEpisodeVisibility(wrapper, { episodeNumber: Number(wrapper.dataset.mdbEpisodeNumber) });
+        });
+        scheduleAutoLoadMoreWhenNoNewEpisodes();
+    }
+
+    function getVisibleMissingEpisodeCount() {
+        return Array.from(document.querySelectorAll(`${config.selectors.episodeWrapper}[data-mdb-episode-number]`))
+            .filter(wrapper => !wrapper.classList.contains(config.classNames.hidden))
+            .filter(wrapper => !existingEpisodes.has(Number(wrapper.dataset.mdbEpisodeNumber)))
+            .length;
+    }
+
+    function getNextPageLink() {
+        return document.querySelector(config.selectors.nextPage);
+    }
+
+    function setAutoLoadMoreFeedback(isLoading) {
+        const nextPage = getNextPageLink();
+        if (!nextPage) return;
+
+        let waiter = nextPage.parentElement?.querySelector(`.${config.classNames.autoLoadMoreWaiter}`);
+        if (!isLoading) {
+            waiter?.remove();
+            return;
+        }
+
+        if (!waiter) {
+            waiter = document.createElement('span');
+            waiter.className = config.classNames.autoLoadMoreWaiter;
+            nextPage.insertAdjacentElement('afterend', waiter);
+        }
+        waiter.textContent = ' Loading hidden episodes…';
+    }
+
+    function scheduleAutoLoadMoreWhenNoNewEpisodes() {
+        clearTimeout(autoLoadMoreTimer);
+        if (!removeExistingEpisodes || autoLoadMoreInProgress) return;
+
+        autoLoadMoreTimer = setTimeout(autoLoadMoreWhenNoNewEpisodes, config.autoLoadMoreDelay);
+    }
+
+    function autoLoadMoreWhenNoNewEpisodes() {
+        const nextPage = getNextPageLink();
+        if (!removeExistingEpisodes || autoLoadMoreInProgress || !nextPage) return;
+
+        const visibleMissingCount = getVisibleMissingEpisodeCount();
+        if (visibleMissingCount > 0 || visibleMissingCount > lastAutoLoadVisibleMissingCount) {
+            lastAutoLoadVisibleMissingCount = visibleMissingCount;
+            return;
+        }
+
+        autoLoadMoreInProgress = true;
+        setAutoLoadMoreFeedback(true);
+        nextPage.click();
+        setTimeout(() => {
+            autoLoadMoreInProgress = false;
+            setAutoLoadMoreFeedback(false);
+            scheduleAutoLoadMoreWhenNoNewEpisodes();
+        }, config.autoLoadMoreDelay);
+    }
+
+    function createRemoveExistingToggle() {
+        const toggleWrapper = document.createElement('label');
+        toggleWrapper.className = config.classNames.toggle;
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = removeExistingEpisodes;
+        checkbox.addEventListener('change', () => {
+            removeExistingEpisodes = checkbox.checked;
+            localStorage.setItem(config.storageKey, removeExistingEpisodes ? 'true' : 'false');
+            lastAutoLoadVisibleMissingCount = getVisibleMissingEpisodeCount();
+            updateEpisodeVisibility();
+        });
+
+        toggleWrapper.append(checkbox, document.createTextNode('Hide episodes that exist on MixesDB'));
+        return toggleWrapper;
+    }
+
+    function addRemoveExistingToggle() {
+        if (document.querySelector(`.${config.classNames.toggle}`)) return;
+
+        const listContainer = document.querySelector(config.selectors.listContainer) || document.body;
+        listContainer.insertAdjacentElement('beforebegin', createRemoveExistingToggle());
+    }
+
+    function createMixesdbLink(heading, episode, wrapper) {
+        const episodeLink = wrapper.querySelector(config.selectors.episodeLink);
+        const link = document.createElement('a');
+
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.dataset.episodeNumber = String(episode.episodeNumber);
+        link.dataset.episodeUrl = episodeLink ? episodeLink.href : location.href;
+        link.addEventListener('click', () => {
+            markLinkVisited(link);
+            wrapper.classList.add(config.classNames.copiedWrapper);
+        });
+        updateMixesdbLink(link, episode, wrapper);
+
+        return link;
+    }
+
+    function createEpisodeCloseButton() {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = config.classNames.closeButton;
+        button.setAttribute('aria-label', 'Hide this episode');
+        button.title = 'Hide this episode';
+        button.textContent = '×';
+        button.addEventListener('click', event => {
+            event.preventDefault();
+            event.stopPropagation();
+            button.closest('article')?.remove();
+        });
+        return button;
+    }
+
+    function addEpisodeCloseButton(wrapper) {
+        if (wrapper.querySelector(`:scope > .${config.classNames.closeButton}`)) return;
+        wrapper.append(createEpisodeCloseButton());
+    }
+
+    function addStyles() {
+        const style = document.createElement('style');
+        style.textContent = `
+            ${config.selectors.episodeWrapper}[data-mdb-episode-number] { position: relative; }
+            ${config.selectors.episodeWrapper}.${config.classNames.copiedWrapper} { opacity: 0.5; }
+            .${config.classNames.closeButton} {
+                align-items: center; background: #00000080; border: 1px solid #ffffff80; border-radius: 50%;
+                color: #fff; cursor: pointer; display: flex; font-size: 1.25rem; font-weight: 700; height: 1.7rem;
+                justify-content: center; line-height: 1; padding: 0; position: absolute; right: 0.6rem; top: 0.6rem; width: 1.7rem; z-index: 2;
+            }
+            .${config.classNames.closeButton}:hover, .${config.classNames.closeButton}:focus { background: #ff6600; border-color: #ff6600; outline: none; }
+            .${config.classNames.link} { display: inline-block; margin: 0.35em 0 0.75em; padding: 0.25em 0.6em; border-radius: 4px; font-size: 0.85rem; font-weight: 700; line-height: 1.4; text-decoration: none; }
+            .${config.classNames.link}.is-visited { opacity: .62 !important; }
+            .${config.classNames.link}.is-existing { background: #2ea70060; color: #fff !important; border: 1px solid #4d9f4d; }
+            .${config.classNames.link}.is-missing, .${config.classNames.link}.is-pending { background: #ff660050; border: 1px solid #f60; color: #fff !important; }
+            .${config.classNames.toggle} { display: block; margin: 0 0 1rem; padding: 0.6em 0.8em; border: 1px solid #4d9f4d; border-radius: 4px; background: #2ea70030; color: #fff; font-size: 0.95rem; font-weight: 700; line-height: 1.4; }
+            .${config.classNames.toggle} input { margin-right: 0.35em; vertical-align: middle; }
+            .${config.classNames.hidden} { display: none !important; }
+            .${config.classNames.autoLoadMoreWaiter} { display: inline-block; margin-left: 0.5rem; color: #fff; font-size: 0.85rem; font-weight: 700; }
+        `;
+        document.head.appendChild(style);
+    }
+
+    function addEpisodeLinks() {
+        document.querySelectorAll(config.selectors.episodeWrapper).forEach(wrapper => {
+            const heading = wrapper.querySelector(config.selectors.episodeHeading);
+            if (!heading || heading.dataset.mdbImporterProcessed === 'true') return;
+
+            const episode = parseEpisodeTitle(heading.textContent.trim());
+            if (!episode) return;
+
+            wrapper.dataset.mdbEpisodeNumber = String(episode.episodeNumber);
+            addEpisodeCloseButton(wrapper);
+            heading.dataset.mdbImporterProcessed = 'true';
+            heading.insertAdjacentElement('afterend', createMixesdbLink(heading, episode, wrapper));
+            setEpisodeVisibility(wrapper, episode);
+        });
+        scheduleAutoLoadMoreWhenNoNewEpisodes();
+    }
+
+    function startEpisodeObserver() {
+        const observer = new MutationObserver(addEpisodeLinks);
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    if (location.hostname === mixesdbHost) {
+        importer.insertMixesdbTextFromUrl();
+        return;
+    }
+
+    if (location.hostname !== sourceHost) return;
+
+    removeExistingEpisodes = localStorage.getItem(config.storageKey) === 'true';
+    loadVisitedEpisodeLinks();
+    addStyles();
+    addRemoveExistingToggle();
+    importer.fetchExistingEpisodes(config)
+        .then(episodeNumbers => {
+            existingEpisodes = new Set(episodeNumbers);
+            addRemoveExistingToggle();
+            addEpisodeLinks();
+            startEpisodeObserver();
+        })
+        .catch(error => {
+            importer.logValue('Failed to load existing IA MIX episodes from MixesDB', error.message || error);
+            addEpisodeLinks();
+            startEpisodeObserver();
+        });
+}());


### PR DESCRIPTION
### Motivation
- Provide Episode Importer support for Inverted Audio IA MIX overview pages so MixesDB creation links can be added from IA MIX cards similar to the existing Resident importer.
- Parse IA MIX episode numbers, artist names, publish dates and embedded player URLs so pages can be populated on MixesDB with correct metadata and player embeds.
- Offer the same import helper UI and workflow (hide existing episodes, visited-state, close buttons, auto-load next pages) used by the Resident importer.

### Description
- Add a new userscript file `private/Episodes_Importer/IA_MIX/script.user.js` with metadata, dated `@version 2026.07.20.1`, and `@include` targeting `https://inverted-audio.com/mix*`.
- Implement episode parsing (`titleEpisodePattern` / `parseEpisodeTitle`) and per-episode detail fetching via `fetch` + `DOMParser` to extract publish dates and player embeds, and build MixesDB titles with `importer.buildMixPageText` and `importer.buildMixesdbUrl`.
- Wire up MixesDB link creation/update using `importer.fetchExistingEpisodes` to mark existing vs missing episodes, and add Resident-style UI: hide-toggle, close buttons, visited-link tracking, auto-load-next-page when only existing episodes are visible, and styles.
- Reuse shared helpers from `funcs.js` and the `MixesDBEpisodesImporter` API and add selectors and config tailored to the IA MIX HTML structure (`#post-load`, `.entry-title`, `.entry-content`, `nav.posts-navigation a.next[href]`).

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js` and it completed without syntax errors.
- Ran `git diff --cached --check` to validate the staged diff and the check returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e318b56f08320a17d0165ad6ebc70)