### PR TITLE
Use Mixcloud API for episode URL imports

### DIFF
--- a/private/Episodes_Importer/get_urls.sh
+++ b/private/Episodes_Importer/get_urls.sh
@@ -5,7 +5,7 @@ usage() {
     cat <<'USAGE'
 Usage: ./get_urls.sh SOUNDCLOUD_OR_MIXCLOUD_URL [cleanup=true|false] [OUTPUT_FILE]
 
-Requires yt-dlp and python3 to be installed.
+Requires python3 to be installed. SoundCloud URLs also require yt-dlp.
 
 Examples:
   cd private/Episodes_Importer
@@ -13,8 +13,8 @@ Examples:
   bash get_urls.sh "https://www.mixcloud.com/inverted_audio/"
   bash get_urls.sh "https://www.mixcloud.com/inverted_audio/" cleanup=false mixcloud_arr.txt
 
-Fetches a SoundCloud playlist/profile or Mixcloud profile/playlist with yt-dlp and
-writes a JavaScript object keyed only by the episode number:
+Fetches a Mixcloud profile/playlist with Mixcloud's public API, or a
+SoundCloud playlist/profile with yt-dlp, and writes a JavaScript object keyed only by the episode number:
 
 var arr = {
     "403": "https://...",
@@ -22,7 +22,7 @@ var arr = {
 };
 
 By default, cleanup=true extracts episode numbers from titles and sorts items by
-episode number descending. Use cleanup=false to keep yt-dlp titles as keys and
+episode number descending. Use cleanup=false to keep source titles as keys and
 source order, which is useful for debugging title parsing.
 USAGE
 }
@@ -34,11 +34,6 @@ fi
 
 if [[ $# -lt 1 || $# -gt 3 ]]; then
     usage >&2
-    exit 1
-fi
-
-if ! command -v yt-dlp >/dev/null 2>&1; then
-    echo "Error: yt-dlp is required but was not found in PATH." >&2
     exit 1
 fi
 
@@ -68,11 +63,61 @@ case "${cleanup_arg}" in
         ;;
 esac
 
-yt-dlp \
-    --ignore-errors \
-    --flat-playlist \
-    --dump-single-json \
-    "${url}" > "${temp_json}"
+if [[ "${url}" == *"mixcloud.com"* ]]; then
+    python3 - "${url}" > "${temp_json}" <<'PYFETCH'
+import json
+import sys
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+source_url = sys.argv[1]
+parsed = urlparse(source_url)
+parts = [part for part in parsed.path.split('/') if part]
+if not parts:
+    raise SystemExit('Error: Mixcloud URL must include a username or playlist path.')
+
+api_base = 'https://api.mixcloud.com/' + '/'.join(parts) + '/'
+api_urls = [api_base]
+if len(parts) == 1:
+    api_urls = [api_base + 'cloudcasts/']
+
+entries = []
+for api_url in api_urls:
+    next_url = api_url
+    while next_url:
+        request = Request(next_url, headers={'User-Agent': 'Mozilla/5.0'})
+        with urlopen(request) as response:
+            payload = json.load(response)
+
+        data = payload.get('data')
+        if isinstance(data, list):
+            entries.extend(data)
+            next_url = (payload.get('paging') or {}).get('next')
+        else:
+            entries.append(payload)
+            connections = payload.get('connections') or {}
+            if 'cloudcasts' in connections and len(parts) > 1:
+                next_url = connections['cloudcasts']
+            else:
+                next_url = None
+
+print(json.dumps({'entries': entries}))
+PYFETCH
+elif [[ "${url}" == *"soundcloud.com"* ]]; then
+    if ! command -v yt-dlp >/dev/null 2>&1; then
+        echo "Error: yt-dlp is required for SoundCloud URLs but was not found in PATH." >&2
+        exit 1
+    fi
+
+    yt-dlp \
+        --ignore-errors \
+        --flat-playlist \
+        --dump-single-json \
+        "${url}" > "${temp_json}"
+else
+    echo "Error: only SoundCloud and Mixcloud URLs are supported." >&2
+    exit 1
+fi
 
 python3 - "${temp_json}" "${output_file}" "${cleanup}" "${url}" <<'PY'
 import json
@@ -101,12 +146,13 @@ def parse_episode(*values):
 
 
 def canonical_url(entry):
-    permalink_url = entry.get("permalink_url") or ""
+    permalink_url = entry.get("permalink_url") or entry.get("url") or ""
     if permalink_url.startswith(("http://", "https://")):
         return permalink_url
 
     webpage_url = entry.get("webpage_url") or ""
     url = entry.get("url") or ""
+    key_url = entry.get("key") or ""
     if webpage_url.startswith(("http://", "https://")) and "api.soundcloud.com" not in webpage_url:
         return webpage_url
     if url.startswith(("http://", "https://")) and "api.soundcloud.com" not in url:
@@ -120,6 +166,9 @@ def canonical_url(entry):
 
     if "soundcloud" in ie_key and uploader and display_id:
         return f"https://soundcloud.com/{uploader}/{display_id}"
+
+    if key_url.startswith("/"):
+        return f"https://www.mixcloud.com{key_url}"
 
     if "mixcloud" in ie_key and uploader and display_id:
         parsed = urlparse(display_id)
@@ -151,11 +200,12 @@ with open(input_path, "r", encoding="utf-8") as handle:
 items = []
 seen = set()
 for entry in walk_entries(data.get("entries") or []):
-    title = entry.get("title") or ""
+    title = entry.get("title") or entry.get("name") or ""
     url = canonical_url(entry)
     key = parse_episode(
         title,
         entry.get("display_id") or "",
+        entry.get("name") or "",
         entry.get("id") or "",
         entry.get("webpage_url") or "",
         entry.get("url") or "",


### PR DESCRIPTION
### Motivation
- Avoid routing Mixcloud profile/playlist fetches through `yt-dlp` to eliminate impersonation warnings and use Mixcloud's public API when possible. 
- Retain `yt-dlp` for SoundCloud because SoundCloud's official API requires app credentials/auth and is less practical for ad-hoc imports. 
- Improve canonical URL and title parsing to handle fields returned by Mixcloud API responses. 

### Description
- Detects Mixcloud URLs and fetches entries directly from `https://api.mixcloud.com/...` via an embedded Python fetcher instead of calling `yt-dlp`. 
- Keeps `yt-dlp` only for `soundcloud.com` URLs and emits a clear error if `yt-dlp` is missing for SoundCloud imports. 
- Updates the help text to reflect the new requirements and behavior in `private/Episodes_Importer/get_urls.sh`. 
- Enhances the Python cleanup/parsing step to use `name`, `key`, and `url` fields and to construct canonical Mixcloud URLs when necessary. 

### Testing
- Ran shell syntax check with `bash -n private/Episodes_Importer/get_urls.sh`, which succeeded. 
- Ran `bash private/Episodes_Importer/get_urls.sh --help` to verify updated usage text, which succeeded. 
- Attempted a live Mixcloud fetch (`bash private/Episodes_Importer/get_urls.sh "https://www.mixcloud.com/inverted_audio/" ...`) but the container environment blocked outbound HTTPS (proxy/tunnel `403 Forbidden`), so live API execution could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e5332b8d08320a5dd251d5e34794e)