### PR TITLE
Use SoundCloud public API to fetch full playlists (yt-dlp fallback)

### DIFF
--- a/private/Episodes_Importer/get_urls.sh
+++ b/private/Episodes_Importer/get_urls.sh
@@ -5,7 +5,7 @@ usage() {
     cat <<'USAGE'
 Usage: ./get_urls.sh SOUNDCLOUD_OR_MIXCLOUD_URL [cleanup=true|false] [OUTPUT_FILE]
 
-Requires python3 to be installed. SoundCloud URLs also require yt-dlp.
+Requires python3 to be installed. SoundCloud URLs use SoundCloud's public web API, with yt-dlp as a fallback when available.
 
 Examples:
   cd private/Episodes_Importer
@@ -14,7 +14,7 @@ Examples:
   bash get_urls.sh "https://www.mixcloud.com/inverted_audio/" cleanup=false mixcloud_arr.txt
 
 Fetches a Mixcloud profile/playlist with Mixcloud's public API, or a
-SoundCloud playlist/profile with yt-dlp, and writes a JavaScript object keyed only by the episode number:
+SoundCloud playlist/profile with SoundCloud's public web API (or yt-dlp fallback), and writes a JavaScript object keyed only by the episode number:
 
 var arr = {
     "403": "https://...",
@@ -104,16 +104,137 @@ for api_url in api_urls:
 print(json.dumps({'entries': entries}))
 PYFETCH
 elif [[ "${url}" == *"soundcloud.com"* ]]; then
-    if ! command -v yt-dlp >/dev/null 2>&1; then
-        echo "Error: yt-dlp is required for SoundCloud URLs but was not found in PATH." >&2
+    if python3 - "${url}" > "${temp_json}" <<'PYFETCH'
+import json
+import re
+import sys
+from html import unescape
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+source_url = sys.argv[1]
+headers = {'User-Agent': 'Mozilla/5.0'}
+
+
+def fetch_text(url):
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=30) as response:
+        return response.read().decode('utf-8', 'replace')
+
+
+def fetch_json(url):
+    request = Request(url, headers={**headers, 'Accept': 'application/json'})
+    with urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def find_client_id(page_html):
+    patterns = [
+        r'client_id\s*[:=]\s*["\']([A-Za-z0-9_-]{20,})["\']',
+        r'client_id=([A-Za-z0-9_-]{20,})',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, page_html)
+        if match:
+            return match.group(1)
+
+    scripts = re.findall(r'<script[^>]+src=["\']([^"\']+\.js)["\']', page_html)
+    for script_url in reversed(scripts):
+        if script_url.startswith('//'):
+            script_url = 'https:' + script_url
+        elif script_url.startswith('/'):
+            script_url = 'https://soundcloud.com' + script_url
+        try:
+            script = fetch_text(unescape(script_url))
+        except (HTTPError, URLError, TimeoutError):
+            continue
+        for pattern in patterns:
+            match = re.search(pattern, script)
+            if match:
+                return match.group(1)
+
+    raise SystemExit('Error: could not locate SoundCloud client_id.')
+
+
+def api_url(path, **params):
+    params = {key: value for key, value in params.items() if value is not None}
+    params['client_id'] = client_id
+    return 'https://api-v2.soundcloud.com' + path + '?' + urlencode(params)
+
+
+def permalink(track):
+    return track.get('permalink_url') or track.get('uri') or track.get('url') or ''
+
+
+def track_entry(track):
+    user = track.get('user') or {}
+    return {
+        'title': track.get('title') or '',
+        'permalink_url': permalink(track),
+        'webpage_url': permalink(track),
+        'url': permalink(track),
+        'id': str(track.get('id') or ''),
+        'display_id': track.get('permalink') or '',
+        'uploader': user.get('permalink') or user.get('username') or '',
+        'ie_key': 'Soundcloud',
+    }
+
+
+def paged_collection(first_url):
+    entries = []
+    next_url = first_url
+    while next_url:
+        payload = fetch_json(next_url)
+        collection = payload.get('collection') if isinstance(payload, dict) else payload
+        if isinstance(collection, list):
+            entries.extend(collection)
+        next_url = payload.get('next_href') if isinstance(payload, dict) else None
+        if next_url and 'client_id=' not in next_url:
+            next_url += ('&' if '?' in next_url else '?') + urlencode({'client_id': client_id})
+    return entries
+
+page = fetch_text(source_url)
+client_id = find_client_id(page)
+resolved = fetch_json(api_url('/resolve', url=source_url))
+kind = resolved.get('kind')
+entries = []
+
+if kind == 'playlist':
+    playlist_id = resolved.get('id')
+    tracks = [track for track in resolved.get('tracks') or [] if track.get('permalink_url')]
+    track_count = resolved.get('track_count') or len(tracks)
+    if playlist_id and len(tracks) < track_count:
+        # SoundCloud embeds only a small preview of large playlists in /resolve.
+        # The playlist tracks endpoint is paginated and returns the full playlist.
+        tracks = paged_collection(api_url(f'/playlists/{playlist_id}/tracks', limit=200, linked_partitioning='1'))
+    entries = [track_entry(track) for track in tracks]
+elif kind == 'user':
+    user_id = resolved.get('id')
+    if not user_id:
+        raise SystemExit('Error: resolved SoundCloud user did not include an id.')
+    tracks = paged_collection(api_url(f'/users/{user_id}/tracks', limit=200, linked_partitioning='1'))
+    entries = [track_entry(track) for track in tracks]
+elif kind == 'track':
+    entries = [track_entry(resolved)]
+else:
+    raise SystemExit(f'Error: unsupported SoundCloud resource kind: {kind!r}')
+
+print(json.dumps({'entries': entries}))
+PYFETCH
+    then
+        :
+    elif command -v yt-dlp >/dev/null 2>&1; then
+        echo "Warning: SoundCloud API fetch failed; falling back to yt-dlp." >&2
+        yt-dlp \
+            --ignore-errors \
+            --flat-playlist \
+            --dump-single-json \
+            "${url}" > "${temp_json}"
+    else
+        echo "Error: SoundCloud API fetch failed and yt-dlp is not installed for fallback." >&2
         exit 1
     fi
-
-    yt-dlp \
-        --ignore-errors \
-        --flat-playlist \
-        --dump-single-json \
-        "${url}" > "${temp_json}"
 else
     echo "Error: only SoundCloud and Mixcloud URLs are supported." >&2
     exit 1


### PR DESCRIPTION
### Motivation
- SoundCloud playlist imports were only returning a small preview of items when using the previous `yt-dlp`-only approach, so the importer needs to retrieve the full, paginated collections.
- The change aims to reliably discover SoundCloud's current `client_id` and call the public web API so playlists and user tracks return all entries instead of a truncated embedded preview.

### Description
- Updated `private/Episodes_Importer/get_urls.sh` help text to document that SoundCloud fetches use SoundCloud's public web API with `yt-dlp` retained as a fallback.
- Added an embedded Python fetch path that discovers `client_id` by scanning the page and linked JS assets, resolves the provided URL via the SoundCloud API, normalizes track objects via `track_entry`, and paginates collections using a `paged_collection` helper.
- For playlists/users the script now requests paginated endpoints (and falls back to the playlist tracks endpoint when `/resolve` contains only a preview), then prints the unified `{'entries': [...]}` JSON consumed by the existing cleanup logic. 
- Kept the previous `yt-dlp --flat-playlist --dump-single-json` behavior as a fallback when the API fetch fails and `yt-dlp` is available, and preserved the existing output formatting that writes `var arr = { ... };`.

### Testing
- Ran shell syntax check with `bash -n private/Episodes_Importer/get_urls.sh`, which completed successfully. 
- Attempted network-based runs such as `bash private/Episodes_Importer/get_urls.sh "https://soundcloud.com/inverted-audio/sets/inverted-audio-mix-series"` and Mixcloud fetches, but they were blocked by the environment proxy resulting in `Tunnel connection failed: 403 Forbidden`, so live API verification was not possible in this environment. 
- The change was committed to the branch and is ready for CI / network-capable environment verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e55d13ba88320849185e0a66715e2)