### PR TITLE
Use IA MIX episode player URL arrays

### DIFF
--- a/private/Episodes_Importer/IA_MIX/player_episodes.js
+++ b/private/Episodes_Importer/IA_MIX/player_episodes.js
@@ -1,4 +1,5 @@
-var arr = {
+window.MixesDBIaMixPlayerEpisodes = (function () {
+const applePodcasts = {
 	"403": "https://podcasts.apple.com/us/podcast/ia-mix-403-eric-cloutier/id1518140453?i=1000777534657",
 	"402": "https://podcasts.apple.com/us/podcast/ia-mix-402-p-relief/id1518140453?i=1000775973369",
 	"401": "https://podcasts.apple.com/us/podcast/ia-mix-401-ulf-eriksson/id1518140453?i=1000768590336",
@@ -316,7 +317,9 @@ var arr = {
 	"84": "https://podcasts.apple.com/us/podcast/ia-mix-84-flako/id1518140453?i=1000477633757"
 };
 
-var arr = {
+const soundcloud = {};
+
+const mixcloud = {
     "403": "https://www.mixcloud.com/inverted_audio/ia-mix-403-eric-cloutier/",
     "402": "https://www.mixcloud.com/inverted_audio/ia-mix-402-p-relief/",
     "401": "https://www.mixcloud.com/inverted_audio/ia-mix-401-ulf-eriksson/",
@@ -715,3 +718,6 @@ var arr = {
     "2": "https://www.mixcloud.com/inverted_audio/ia-mix-02-christopher-rau/",
     "1": "https://www.mixcloud.com/inverted_audio/i-a-mix-01-singing-statues/",
 };
+
+    return { applePodcasts, mixcloud, soundcloud };
+}());

--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.1
+// @version      2026.07.20.2
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.1
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.2
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.2
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -34,6 +35,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     const sourceHost = 'inverted-audio.com';
+    const playerEpisodes = window.MixesDBIaMixPlayerEpisodes || {};
     const mixesdbHost = 'www.mixesdb.com';
     const config = {
         categoryTitle: 'Category:IA_MIX',
@@ -145,18 +147,41 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return `${prefix}${episode.artist} - IA MIX ${importer.padNumber(episode.episodeNumber)}`;
     }
 
-    function buildEpisodePageText(episode, playerUrl = '') {
-        return importer.buildMixPageText({
-            year: episode.date ? episode.date.slice(0, 4) : '',
-            artist: episode.artist,
-            showCategory: config.showCategory,
-            tracklistResult: { text: '<list>\n\n</list>', status: 'none' },
-            playerUrl,
-        });
+    function getPlayerUrlsForEpisode(episode, fetchedPlayerUrl = '') {
+        const episodeKey = String(episode.episodeNumber);
+        const playerUrls = [
+            playerEpisodes.applePodcasts?.[episodeKey],
+            playerEpisodes.mixcloud?.[episodeKey],
+            playerEpisodes.soundcloud?.[episodeKey],
+            fetchedPlayerUrl,
+        ].filter(Boolean);
+
+        return Array.from(new Set(playerUrls));
     }
 
-    function setCreateLinkHref(link, episode, episodeUrl, playerUrl = '') {
-        link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, playerUrl));
+    function buildPlayerText(playerUrls) {
+        if (!playerUrls.length) return '';
+
+        const playerLines = playerUrls.map((playerUrl, index) => {
+            const prefix = playerUrls.length > 1 || playerUrl.includes('=') ? `${index + 1}=` : '';
+            return ` |${prefix}${playerUrl}`;
+        });
+
+        return `\n\n{{Player\n${playerLines.join('\n')}\n}}`;
+    }
+
+    function buildEpisodePageText(episode, fetchedPlayerUrl = '') {
+        const tracklistResult = { text: '<list>\n\n</list>', status: 'none' };
+        const categories = [episode.date ? episode.date.slice(0, 4) : '', episode.artist, config.showCategory, `Tracklist: ${tracklistResult.status}`]
+            .filter(Boolean)
+            .map(category => `[[Category:${category}]]`)
+            .join('\n');
+
+        return `== File details ==\n\n{{StandardShow1h}}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
+    }
+
+    function setCreateLinkHref(link, episode, episodeUrl, fetchedPlayerUrl = '') {
+        link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, fetchedPlayerUrl));
     }
 
     async function updateMixesdbLink(link, episode, wrapper) {


### PR DESCRIPTION
### Motivation
- Use the episode URL arrays (Apple Podcasts, Mixcloud, SoundCloud) when generating the MixesDB player template for IA MIX episodes.
- Load the arrays as a separate dependency so the importer can include all known player URLs (plus any URL fetched from the page) in the generated MixesDB episode text.

### Description
- Add `private/Episodes_Importer/IA_MIX/player_episodes.js` which exposes the maps as `window.MixesDBIaMixPlayerEpisodes` with `applePodcasts`, `mixcloud`, and `soundcloud` exports.
- Update `private/Episodes_Importer/IA_MIX/script.user.js` to `@require` the new `player_episodes.js`, bump the userscript version to `2026.07.20.2`, and update the `funcs.js` cache version reference.
- Introduce `playerEpisodes` lookup and new helper functions `getPlayerUrlsForEpisode` and `buildPlayerText` to aggregate and deduplicate `applePodcasts`, `mixcloud`, `soundcloud`, and any `fetchedPlayerUrl` into a multi-line `{{Player}}` block that numbers lines when required.
- Replace the previous single-URL `buildEpisodePageText`/`setCreateLinkHref` usage with the new aggregated player-URL flow so created MixesDB pages include all known player links.

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js` and it completed successfully.
- Ran `node --check private/Episodes_Importer/IA_MIX/player_episodes.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e5b011d0083208c2755705dad3959)