### PR TITLE
IA MIX: use .posted-on date, add image & Techno category, bump version

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.2
+// @version      2026.07.20.3
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,8 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.2
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.2
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.3
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.3
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -120,11 +120,15 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     function extractDateFromDocument(doc) {
+        const postedOn = doc.querySelector('.posted-on');
         const candidates = [
+            postedOn?.querySelector('time.entry-date.published[datetime]')?.getAttribute('datetime'),
+            postedOn?.querySelector('time[datetime]')?.getAttribute('datetime'),
+            postedOn?.textContent,
             doc.querySelector('time[datetime]')?.getAttribute('datetime'),
             doc.querySelector('meta[property="article:published_time"]')?.content,
             doc.querySelector('meta[name="date"]')?.content,
-            doc.querySelector('.entry-date, .posted-on, .entry-meta')?.textContent,
+            doc.querySelector('.entry-date, .entry-meta')?.textContent,
         ];
 
         return candidates.map(normalizeDate).find(Boolean) || '';
@@ -170,14 +174,20 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return `\n\n{{Player\n${playerLines.join('\n')}\n}}`;
     }
 
+    function buildImageReference(episode) {
+        return episode.date ? `[[File:${buildMixesdbTitle(episode)}.jpg|right|360px]]` : '';
+    }
+
     function buildEpisodePageText(episode, fetchedPlayerUrl = '') {
         const tracklistResult = { text: '<list>\n\n</list>', status: 'none' };
-        const categories = [episode.date ? episode.date.slice(0, 4) : '', episode.artist, config.showCategory, `Tracklist: ${tracklistResult.status}`]
+        const categories = [episode.date ? episode.date.slice(0, 4) : '', episode.artist, config.showCategory, 'Techno', `Tracklist: ${tracklistResult.status}`]
             .filter(Boolean)
             .map(category => `[[Category:${category}]]`)
             .join('\n');
+        const imageReference = buildImageReference(episode);
+        const imageText = imageReference ? `${imageReference}\n\n` : '';
 
-        return `== File details ==\n\n{{StandardShow1h}}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
+        return `${imageText}== File details ==\n\n{{StandardShow1h}}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
     }
 
     function setCreateLinkHref(link, episode, episodeUrl, fetchedPlayerUrl = '') {
@@ -315,6 +325,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.rel = 'noopener noreferrer';
         link.dataset.episodeNumber = String(episode.episodeNumber);
         link.dataset.episodeUrl = episodeLink ? episodeLink.href : location.href;
+        link.href = link.dataset.episodeUrl;
         link.addEventListener('click', () => {
             markLinkVisited(link);
             wrapper.classList.add(config.classNames.copiedWrapper);


### PR DESCRIPTION
### Motivation
- Provide an episode date for IA MIX pages by preferring the `.posted-on` published timestamp when available so MixesDB titles include the date. 
- Make the “Copy to MixesDB” flow immediately link to the source episode URL while creation metadata is fetched. 
- Insert an image reference and a sensible default style category into the generated MixesDB page to improve wiki page output. 

### Description
- Bumped the userscript `@version` and cache-busting `@require` query strings to `2026.07.20.3` in `private/Episodes_Importer/IA_MIX/script.user.js`.
- Updated `extractDateFromDocument` to prefer `.posted-on` and `time.entry-date.published[datetime]` before falling back to other metadata. 
- Added `buildImageReference` and prepend the image line `[[File:<title>.jpg|right|360px]]` above `== File details ==` when a date/title exists. 
- Inserted `[[Category:Techno]]` by default (before the `Tracklist` status category) in the generated page text. 
- Set newly created MixesDB links to the episode URL immediately by assigning `link.href = link.dataset.episodeUrl` while the script finishes fetching MixesDB creation details. 

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js`, which succeeded. 
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e5d3e69ec8320b288b0fd9839c9eb)