### PR TITLE
IA MIX: fix import output, date extraction diagnostics, player mirrors and image reference

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.3
+// @version      2026.07.20.4
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,8 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.3
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.3
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.4
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.4
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -119,19 +119,26 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return `${longDateMatch[3]}-${month}-${String(longDateMatch[2]).padStart(2, '0')}`;
     }
 
-    function extractDateFromDocument(doc) {
+    function extractDateFromDocument(doc, episodeUrl = '') {
         const postedOn = doc.querySelector('.posted-on');
         const candidates = [
-            postedOn?.querySelector('time.entry-date.published[datetime]')?.getAttribute('datetime'),
-            postedOn?.querySelector('time[datetime]')?.getAttribute('datetime'),
-            postedOn?.textContent,
-            doc.querySelector('time[datetime]')?.getAttribute('datetime'),
-            doc.querySelector('meta[property="article:published_time"]')?.content,
-            doc.querySelector('meta[name="date"]')?.content,
-            doc.querySelector('.entry-date, .entry-meta')?.textContent,
+            { source: '.posted-on time.entry-date.published[datetime]', value: postedOn?.querySelector('time.entry-date.published[datetime]')?.getAttribute('datetime') },
+            { source: '.posted-on time[datetime]', value: postedOn?.querySelector('time[datetime]')?.getAttribute('datetime') },
+            { source: '.posted-on text', value: postedOn?.textContent },
+            { source: 'time[datetime]', value: doc.querySelector('time[datetime]')?.getAttribute('datetime') },
+            { source: 'meta[property="article:published_time"]', value: doc.querySelector('meta[property="article:published_time"]')?.content },
+            { source: 'meta[name="date"]', value: doc.querySelector('meta[name="date"]')?.content },
+            { source: '.entry-date, .entry-meta text', value: doc.querySelector('.entry-date, .entry-meta')?.textContent },
         ];
+        const normalizedCandidates = candidates.map(candidate => ({
+            source: candidate.source,
+            value: String(candidate.value || '').trim(),
+            normalized: normalizeDate(candidate.value),
+        }));
+        const selected = normalizedCandidates.find(candidate => candidate.normalized);
+        logStep('date extraction candidates', { episodeUrl, candidates: normalizedCandidates, selected: selected || null });
 
-        return candidates.map(normalizeDate).find(Boolean) || '';
+        return selected?.normalized || '';
     }
 
     async function fetchEpisodeDetails(episodeUrl) {
@@ -141,7 +148,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         const html = await response.text();
         const doc = new DOMParser().parseFromString(html, 'text/html');
         return {
-            date: extractDateFromDocument(doc),
+            date: extractDateFromDocument(doc, episodeUrl),
             playerUrl: doc.querySelector('iframe[src*="soundcloud.com"], iframe[src*="mixcloud.com"], iframe[src*="hearthis.at"], audio[src], audio source[src]')?.src || '',
         };
     }
@@ -170,12 +177,13 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             const prefix = playerUrls.length > 1 || playerUrl.includes('=') ? `${index + 1}=` : '';
             return ` |${prefix}${playerUrl}`;
         });
+        const modeLine = playerUrls.length > 1 ? ' |mode=mirrors\n' : '';
 
-        return `\n\n{{Player\n${playerLines.join('\n')}\n}}`;
+        return `\n\n{{Player\n${modeLine}${playerLines.join('\n')}\n}}`;
     }
 
     function buildImageReference(episode) {
-        return episode.date ? `[[File:${buildMixesdbTitle(episode)}.jpg|right|360px]]` : '';
+        return `[[File:${buildMixesdbTitle(episode)}.jpg|right|360px]]`;
     }
 
     function buildEpisodePageText(episode, fetchedPlayerUrl = '') {
@@ -194,6 +202,23 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, fetchedPlayerUrl));
     }
 
+    function bindCreateLinkRefreshOnClick(link, episode, episodeUrl) {
+        if (link.dataset.mdbIaMixCreateLinkRefresh === '1') return;
+
+        link.dataset.mdbIaMixCreateLinkRefresh = '1';
+        link.addEventListener('click', () => {
+            if (existingEpisodes.has(episode.episodeNumber)) return;
+            setCreateLinkHref(link, episode, episodeUrl, link.dataset.playerUrl || '');
+            logStep('refreshed create link on click', {
+                episodeNumber: episode.episodeNumber,
+                episodeUrl,
+                title: buildMixesdbTitle(episode),
+                date: episode.date || '',
+                playerUrl: link.dataset.playerUrl || '',
+            });
+        }, { capture: true });
+    }
+
     async function updateMixesdbLink(link, episode, wrapper) {
         const episodeUrl = link.dataset.episodeUrl || location.href;
         const isExisting = existingEpisodes.has(episode.episodeNumber);
@@ -201,10 +226,13 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         link.className = `${config.classNames.link} ${isExisting ? 'is-existing' : 'is-pending'}`;
         link.textContent = isExisting ? 'See on MixesDB' : `Checking IA MIX ${importer.padNumber(episode.episodeNumber)}`;
         setLinkVisitedState(link);
+        bindCreateLinkRefreshOnClick(link, episode, episodeUrl);
 
         try {
             const details = await fetchEpisodeDetails(episodeUrl);
             episode.date = details.date;
+            link.dataset.playerUrl = details.playerUrl || '';
+            logStep('fetched episode details', { episodeNumber: episode.episodeNumber, episodeUrl, date: details.date, playerUrl: details.playerUrl });
             if (isExisting) {
                 link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl);
             } else {

--- a/private/Episodes_Importer/get_urls.sh
+++ b/private/Episodes_Importer/get_urls.sh
@@ -16,10 +16,12 @@ Examples:
 Fetches a Mixcloud profile/playlist with Mixcloud's public API, or a
 SoundCloud playlist/profile with SoundCloud's public web API (or yt-dlp fallback), and writes a JavaScript object keyed only by the episode number:
 
-var arr = {
+const soundcloud = {
     "403": "https://...",
     "402": "https://..."
 };
+
+The variable name is selected from the source URL, for example const soundcloud = { ... }; or const mixcloud = { ... };
 
 By default, cleanup=true extracts episode numbers from titles and sorts items by
 episode number descending. Use cleanup=false to keep source titles as keys and
@@ -280,6 +282,7 @@ from urllib.parse import urlparse
 
 input_path, output_path, cleanup_arg, source_url = sys.argv[1:5]
 cleanup = cleanup_arg == "true"
+source_variable = "mixcloud" if "mixcloud.com" in source_url else "soundcloud" if "soundcloud.com" in source_url else "urls"
 
 EPISODE_PATTERNS = [
     re.compile(r"\bia[\s_-]*mix(?:[\s_-]*series)?[\s_#.:/-]*(?P<episode>\d{1,5})\b", re.I),
@@ -381,7 +384,7 @@ if cleanup:
     items.sort(key=lambda item: int(item[0]), reverse=True)
 
 with open(output_path, "w", encoding="utf-8") as handle:
-    handle.write("var arr = {\n")
+    handle.write(f"const {source_variable} = {{\n")
 
     for key, url in items:
         key_json = json.dumps(key, ensure_ascii=False)


### PR DESCRIPTION
### Motivation
- Ensure `get_urls.sh` emits a source-specific JS object name so downstream code can read `const soundcloud = { ... }`/`const mixcloud = { ... }` instead of a generic `var arr`.
- Help diagnose and fix a remaining date-parsing bug by logging all candidate date sources when fetching episode detail pages.
- Make the generated Player template correct when multiple player URLs are present and ensure an image reference is always included at the top of created pages.
- Make the Copy/Create link use the freshest resolved episode state (date/player URL) at click time so overview/detail behaviour is consistent.

### Description
- Bump IA MIX userscript cache/version references to `2026.07.20.4` in `private/Episodes_Importer/IA_MIX/script.user.js` and related `@require` query strings. 
- Update `private/Episodes_Importer/get_urls.sh` to write the output as a source-specific `const` object (sets `source_variable` and writes `const {source_variable} = { ... }`).
- Add verbose date-extraction diagnostics in `IA_MIX/script.user.js` by collecting candidate sources, normalizing them, logging candidates and the selected normalized date via `logStep`, and pass `episodeUrl` into the extractor for context.
- Add `bindCreateLinkRefreshOnClick` to refresh the MixesDB create-link href on click using the latest `episode.date` and `playerUrl`, and store `playerUrl` on the link when fetching details.
- Change Player rendering so multi-URL cases include `|mode=mirrors` and always include the image reference at the top of the page text regardless of whether a date was found.

### Testing
- Ran a shell syntax check with `bash -n private/Episodes_Importer/get_urls.sh`, which succeeded. 
- Performed JS static checks with `node --check` on `private/Episodes_Importer/IA_MIX/script.user.js`, `private/Episodes_Importer/funcs.js`, and `private/Episodes_Importer/IA_MIX/player_episodes.js`, all of which succeeded. 
- Ran repository checks with `git diff --check`, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e60d5f3288320b198706e623baa76)