### PR TITLE
IA_MIX: dynamic player_episodes load, Player template fix, include durations in get_urls.sh

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.4
+// @version      2026.07.20.5
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,8 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.4
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.4
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.5
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -35,7 +34,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     const sourceHost = 'inverted-audio.com';
-    const playerEpisodes = window.MixesDBIaMixPlayerEpisodes || {};
+    let playerEpisodes = {};
     const mixesdbHost = 'www.mixesdb.com';
     const config = {
         categoryTitle: 'Category:IA_MIX',
@@ -51,6 +50,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             episodeLink: '.entry-title a[href], .entry-img a[href]',
             description: '.entry-content',
             nextPage: 'nav.posts-navigation a.next[href]',
+            postedOn: '.posted-on',
         },
         classNames: {
             link: 'mdb-ia-mix-link',
@@ -158,12 +158,16 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return `${prefix}${episode.artist} - IA MIX ${importer.padNumber(episode.episodeNumber)}`;
     }
 
+    function normalizePlayerEpisodeEntry(entry) {
+        return typeof entry === 'object' && entry !== null ? entry.url : entry;
+    }
+
     function getPlayerUrlsForEpisode(episode, fetchedPlayerUrl = '') {
         const episodeKey = String(episode.episodeNumber);
         const playerUrls = [
-            playerEpisodes.applePodcasts?.[episodeKey],
-            playerEpisodes.mixcloud?.[episodeKey],
-            playerEpisodes.soundcloud?.[episodeKey],
+            normalizePlayerEpisodeEntry(playerEpisodes.applePodcasts?.[episodeKey]),
+            normalizePlayerEpisodeEntry(playerEpisodes.mixcloud?.[episodeKey]),
+            normalizePlayerEpisodeEntry(playerEpisodes.soundcloud?.[episodeKey]),
             fetchedPlayerUrl,
         ].filter(Boolean);
 
@@ -177,9 +181,11 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             const prefix = playerUrls.length > 1 || playerUrl.includes('=') ? `${index + 1}=` : '';
             return ` |${prefix}${playerUrl}`;
         });
-        const modeLine = playerUrls.length > 1 ? ' |mode=mirrors\n' : '';
+        if (playerUrls.length > 1) {
+            return `\n\n{{Player|mode=mirrors\n${playerLines.join('\n')}\n}}`;
+        }
 
-        return `\n\n{{Player\n${modeLine}${playerLines.join('\n')}\n}}`;
+        return `\n\n{{Player\n${playerLines.join('\n')}\n}}`;
     }
 
     function buildImageReference(episode) {
@@ -345,14 +351,29 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         listContainer.insertAdjacentElement('beforebegin', createRemoveExistingToggle());
     }
 
+    function getEpisodeUrl(wrapper) {
+        const episodeLink = wrapper.querySelector(config.selectors.episodeLink)
+            || wrapper.querySelector('a[rel=\"bookmark\"][href*=\"/mix/\"], a[href*=\"/mix/\"]');
+        return episodeLink ? episodeLink.href : location.href;
+    }
+
+    function hydrateEpisodeDateFromWrapper(episode, wrapper) {
+        if (episode.date) return;
+
+        const postedOn = wrapper.querySelector(config.selectors.postedOn);
+        const datetime = postedOn?.querySelector('time.entry-date.published[datetime], time[datetime]')?.getAttribute('datetime');
+        episode.date = normalizeDate(datetime) || normalizeDate(postedOn?.textContent);
+    }
+
     function createMixesdbLink(heading, episode, wrapper) {
-        const episodeLink = wrapper.querySelector(config.selectors.episodeLink);
+        hydrateEpisodeDateFromWrapper(episode, wrapper);
+        const episodeUrl = getEpisodeUrl(wrapper);
         const link = document.createElement('a');
 
         link.target = '_blank';
         link.rel = 'noopener noreferrer';
         link.dataset.episodeNumber = String(episode.episodeNumber);
-        link.dataset.episodeUrl = episodeLink ? episodeLink.href : location.href;
+        link.dataset.episodeUrl = episodeUrl;
         link.href = link.dataset.episodeUrl;
         link.addEventListener('click', () => {
             markLinkVisited(link);
@@ -423,6 +444,15 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         scheduleAutoLoadMoreWhenNoNewEpisodes();
     }
 
+    async function loadPlayerEpisodes() {
+        const url = 'https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?fresh=' + Date.now();
+        const response = await fetch(url, { cache: 'no-store' });
+        if (!response.ok) throw new Error(`player_episodes.js responded with ${response.status}`);
+        const code = await response.text();
+        (0, eval)(code);
+        playerEpisodes = window.MixesDBIaMixPlayerEpisodes || {};
+    }
+
     function startEpisodeObserver() {
         const observer = new MutationObserver(addEpisodeLinks);
         observer.observe(document.body, { childList: true, subtree: true });
@@ -439,7 +469,9 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     loadVisitedEpisodeLinks();
     addStyles();
     addRemoveExistingToggle();
-    importer.fetchExistingEpisodes(config)
+    loadPlayerEpisodes()
+        .catch(error => importer.logValue('Failed to load fresh IA MIX player episodes', error.message || error))
+        .then(() => importer.fetchExistingEpisodes(config))
         .then(episodeNumbers => {
             existingEpisodes = new Set(episodeNumbers);
             addRemoveExistingToggle();

--- a/private/Episodes_Importer/get_urls.sh
+++ b/private/Episodes_Importer/get_urls.sh
@@ -180,6 +180,8 @@ def track_entry(track):
         'id': str(track.get('id') or ''),
         'display_id': track.get('permalink') or '',
         'uploader': user.get('permalink') or user.get('username') or '',
+        'duration': track.get('duration') or 0,
+        'duration_ms': track.get('duration') or 0,
         'ie_key': 'Soundcloud',
     }
 
@@ -339,6 +341,24 @@ def canonical_url(entry):
     return webpage_url or url
 
 
+def normalized_duration(entry):
+    raw_duration = entry.get("duration") or entry.get("audio_length") or entry.get("duration_ms") or 0
+    if not raw_duration:
+        return 0
+
+    try:
+        duration = float(raw_duration)
+    except (TypeError, ValueError):
+        return 0
+
+    if entry.get("duration_ms") and not entry.get("duration"):
+        duration = duration / 1000
+    elif source_variable == "soundcloud" and duration > 360000:
+        duration = duration / 1000
+
+    return round(duration)
+
+
 def walk_entries(items):
     for item in items or []:
         if not item:
@@ -358,6 +378,7 @@ seen = set()
 for entry in walk_entries(data.get("entries") or []):
     title = entry.get("title") or entry.get("name") or ""
     url = canonical_url(entry)
+    duration = normalized_duration(entry)
     key = parse_episode(
         title,
         entry.get("display_id") or "",
@@ -378,7 +399,7 @@ for entry in walk_entries(data.get("entries") or []):
         continue
 
     seen.add(key)
-    items.append((key, url))
+    items.append((key, url, duration))
 
 if cleanup:
     items.sort(key=lambda item: int(item[0]), reverse=True)
@@ -386,10 +407,13 @@ if cleanup:
 with open(output_path, "w", encoding="utf-8") as handle:
     handle.write(f"const {source_variable} = {{\n")
 
-    for key, url in items:
+    for key, url, duration in items:
         key_json = json.dumps(key, ensure_ascii=False)
-        url_json = json.dumps(url, ensure_ascii=False)
-        handle.write(f"    {key_json}: {url_json},\n")
+        value = {'url': url}
+        if duration:
+            value['duration'] = duration
+        value_json = json.dumps(value, ensure_ascii=False)
+        handle.write(f"    {key_json}: {value_json},\n")
 
     handle.write("};\n")
 PY


### PR DESCRIPTION
### Motivation

- Ensure player episode data is loaded fresh on every page load instead of bundling `player_episodes.js` into the userscript metadata.  
- Preserve episode duration information from SoundCloud/Mixcloud API responses so downstream code can use durations.  
- Fix Player wiki template formatting and improve overview-page date/URL extraction so created MixesDB links are accurate.

### Description

- Remove `player_episodes.js` from `@require`, bump IA MIX userscript version to `2026.07.20.5`, and add a runtime `loadPlayerEpisodes()` that fetches `player_episodes.js` with `?fresh=` + `Date.now()` and `cache: 'no-store'`.  
- Make `playerEpisodes` accept object-style entries and add `normalizePlayerEpisodeEntry()` so entries like `{ url, duration }` work while plain URL strings remain supported.  
- Rewrite `buildPlayerText()` so mirrored Player output starts with `{{Player|mode=mirrors` on the opening template line.  
- Add `postedOn` selector, `getEpisodeUrl()` and `hydrateEpisodeDateFromWrapper()` to read `.posted-on` dates from overview cards and resolve episode detail URLs more robustly before constructing MixesDB create links.  
- Update `private/Episodes_Importer/get_urls.sh` embedded Python to capture and normalize durations (`normalized_duration`) from Mixcloud/SoundCloud/yt-dlp results and change output entries from string URLs to objects like `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e62fa0c688320a8561ff0275b432e)