### PR TITLE
Use precise IA MIX duration tables

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.5
+// @version      2026.07.20.6
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.5
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.6
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -174,6 +174,40 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return Array.from(new Set(playerUrls));
     }
 
+    function getEpisodeDurationSeconds(episode) {
+        const episodeKey = String(episode.episodeNumber);
+        const entries = [
+            playerEpisodes.applePodcasts?.[episodeKey],
+            playerEpisodes.mixcloud?.[episodeKey],
+            playerEpisodes.soundcloud?.[episodeKey],
+        ];
+        const duration = entries
+            .map(entry => Number(entry?.duration))
+            .find(candidate => Number.isFinite(candidate) && candidate > 0);
+
+        return duration || null;
+    }
+
+    function formatDuration(seconds) {
+        const totalSeconds = Math.round(seconds);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const remainingSeconds = totalSeconds % 60;
+
+        if (hours > 0) {
+            return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
+        }
+
+        return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+    }
+
+    function buildFileDetailsText(episode) {
+        const durationSeconds = getEpisodeDurationSeconds(episode);
+        const duration = durationSeconds ? formatDuration(durationSeconds) : '';
+
+        return `{|{{NormalTableFormat}}\n! dur\n! MB\n! kbps\n|-\n| ${duration}\n| \n| \n|}`;
+    }
+
     function buildPlayerText(playerUrls) {
         if (!playerUrls.length) return '';
 
@@ -201,7 +235,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         const imageReference = buildImageReference(episode);
         const imageText = imageReference ? `${imageReference}\n\n` : '';
 
-        return `${imageText}== File details ==\n\n{{StandardShow1h}}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
+        return `${imageText}== File details ==\n\n${buildFileDetailsText(episode)}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
     }
 
     function setCreateLinkHref(link, episode, episodeUrl, fetchedPlayerUrl = '') {


### PR DESCRIPTION
### Motivation
- Replace the generic `{{StandardShow1h}}` file-details output with a small table so durations can be shown precisely when available.
- Use existing `player_episodes` metadata to display an accurate episode duration instead of the default 1h placeholder.
- Ensure the userscript and its dependency cache version are current for today’s update.

### Description
- Replaced the `{{StandardShow1h}}` block in `buildEpisodePageText` with a `NormalTableFormat` file-details table produced by a new `buildFileDetailsText` helper. (file: `private/Episodes_Importer/IA_MIX/script.user.js`)
- Added `getEpisodeDurationSeconds` to pick a duration from `playerEpisodes.applePodcasts`, `playerEpisodes.mixcloud`, or `playerEpisodes.soundcloud` and `formatDuration` to render seconds as `h:mm:ss` or `m:ss`.
- `buildFileDetailsText` formats the table with the calculated `dur` cell and leaves `MB`/`kbps` blank by default.
- Bumped the IA MIX userscript `@version` and the `funcs.js` `v-` cache suffix to today’s update.

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js` and it completed without syntax errors. (success)
- Executed a runtime check of `formatDuration(9088)` and confirmed it returns `2:31:28`. (success)
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e66c658b4832082ec15f30276b3b0)