### PR TITLE
Fix IA MIX detail page date hydration

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.6
+// @version      2026.07.20.7
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.6
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.7
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -51,6 +51,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             description: '.entry-content',
             nextPage: 'nav.posts-navigation a.next[href]',
             postedOn: '.posted-on',
+            postedOnTime: '.posted-on time.entry-date.published[datetime], .posted-on time[datetime]',
         },
         classNames: {
             link: 'mdb-ia-mix-link',
@@ -270,7 +271,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
 
         try {
             const details = await fetchEpisodeDetails(episodeUrl);
-            episode.date = details.date;
+            episode.date = details.date || episode.date;
             link.dataset.playerUrl = details.playerUrl || '';
             logStep('fetched episode details', { episodeNumber: episode.episodeNumber, episodeUrl, date: details.date, playerUrl: details.playerUrl });
             if (isExisting) {
@@ -392,11 +393,39 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     function hydrateEpisodeDateFromWrapper(episode, wrapper) {
-        if (episode.date) return;
+        if (episode.date) return false;
 
         const postedOn = wrapper.querySelector(config.selectors.postedOn);
-        const datetime = postedOn?.querySelector('time.entry-date.published[datetime], time[datetime]')?.getAttribute('datetime');
+        const datetime = postedOn?.querySelector(config.selectors.postedOnTime)?.getAttribute('datetime');
         episode.date = normalizeDate(datetime) || normalizeDate(postedOn?.textContent);
+        return Boolean(episode.date);
+    }
+
+    function updateLinkDateFromPostedOn(link, episode, wrapper, postedOn) {
+        if (episode.date) return;
+
+        const datetime = postedOn.querySelector(config.selectors.postedOnTime)?.getAttribute('datetime');
+        const date = normalizeDate(datetime) || normalizeDate(postedOn.textContent);
+        if (!date) return;
+
+        episode.date = date;
+        setCreateLinkHref(link, episode, link.dataset.episodeUrl || location.href, link.dataset.playerUrl || '');
+        link.title = buildMixesdbTitle(episode);
+        logStep('hydrated detail page date from .posted-on', {
+            episodeNumber: episode.episodeNumber,
+            episodeUrl: link.dataset.episodeUrl || location.href,
+            date,
+        });
+    }
+
+    function waitForPostedOnDate(link, episode, wrapper) {
+        if (episode.date || typeof waitForKeyElements !== 'function') return;
+
+        const selector = `${config.selectors.episodeWrapper}[data-mdb-episode-number="${episode.episodeNumber}"] ${config.selectors.postedOn}`;
+        waitForKeyElements(selector, jNode => {
+            updateLinkDateFromPostedOn(link, episode, wrapper, jNode[0]);
+            return !episode.date;
+        }, true);
     }
 
     function createMixesdbLink(heading, episode, wrapper) {
@@ -414,6 +443,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             wrapper.classList.add(config.classNames.copiedWrapper);
         });
         updateMixesdbLink(link, episode, wrapper);
+        waitForPostedOnDate(link, episode, wrapper);
 
         return link;
     }


### PR DESCRIPTION
### Motivation
- Ensure episode dates are correctly captured from Inverted Audio detail pages (e.g. `/mix/p-relief/`) where the `.posted-on time` element can appear after initial render. 
- Prevent a blank date fetched from the episode detail HTML from overwriting a date already hydrated from the listing DOM. 
- Bump the userscript/cache tokens to reflect the fix and today's date (`2026.07.20`).

### Description
- Bumped the IA MIX userscript `@version` to `2026.07.20.7` and updated the `funcs.js` require cache token to `v-2026.07.20.7` in `private/Episodes_Importer/IA_MIX/script.user.js`.
- Added a shared selector `postedOnTime: '.posted-on time.entry-date.published[datetime], .posted-on time[datetime]'` and used it when extracting `datetime` values. 
- Made `hydrateEpisodeDateFromWrapper` return a boolean and switched it to use `config.selectors.postedOnTime`; added `updateLinkDateFromPostedOn` and `waitForPostedOnDate` which use `waitForKeyElements` to watch for a delayed `.posted-on` element and refresh the MixesDB create link title/href once a published `datetime` is available. 
- Preserved an already-hydrated date when fetching detail HTML by changing `episode.date = details.date || episode.date` so blank fetched dates do not overwrite local values.

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js` and it succeeded. 
- Ran `git diff --check` and it reported no problems. 
- Verified the file was committed after the changes (local repo status checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e684ebb988320b084ba4f83e8519e)