### PR TITLE
IA MIX: fix ISO datetime date parsing and bump version

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.7
+// @version      2026.07.20.8
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.7
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.8
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -108,7 +108,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     function normalizeDate(dateText) {
-        const isoMatch = String(dateText || '').match(/\b(\d{4})-(\d{2})-(\d{2})\b/);
+        const isoMatch = String(dateText || '').match(/\b(\d{4})-(\d{2})-(\d{2})(?=\b|T)/);
         if (isoMatch) return isoMatch[0];
 
         const longDateMatch = String(dateText || '').match(/\b([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})\b/);


### PR DESCRIPTION
### Motivation
- The IA MIX importer failed to extract dates from ISO datetime strings like `2026-07-08T14:23:19+00:00`, so page titles were missing the date prefix.

### Description
- Update the `normalizeDate` logic in `private/Episodes_Importer/IA_MIX/script.user.js` to use a stricter ISO match (`/\b(\d{4})-(\d{2})-(\d{2})(?=\b|T)/`) so datetimes normalize to `YYYY-MM-DD`.
- Bump the IA MIX userscript version and helper cache-buster references to `2026.07.20.8` so the updated helper is loaded.

### Testing
- Ran a small `node` snippet that exercises `normalizeDate` against an ISO datetime and a posted-text date, and it returned the expected `YYYY-MM-DD` values (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e699f90c48320853850b15b846c19)