### PR TITLE
Prefer configured IA MIX player URLs and add Notes section

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.8
+// @version      2026.07.20.9
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.8
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.9
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -165,12 +165,12 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
 
     function getPlayerUrlsForEpisode(episode, fetchedPlayerUrl = '') {
         const episodeKey = String(episode.episodeNumber);
-        const playerUrls = [
+        const configuredPlayerUrls = [
             normalizePlayerEpisodeEntry(playerEpisodes.applePodcasts?.[episodeKey]),
             normalizePlayerEpisodeEntry(playerEpisodes.mixcloud?.[episodeKey]),
             normalizePlayerEpisodeEntry(playerEpisodes.soundcloud?.[episodeKey]),
-            fetchedPlayerUrl,
         ].filter(Boolean);
+        const playerUrls = configuredPlayerUrls.length ? configuredPlayerUrls : [fetchedPlayerUrl].filter(Boolean);
 
         return Array.from(new Set(playerUrls));
     }
@@ -227,7 +227,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return `[[File:${buildMixesdbTitle(episode)}.jpg|right|360px]]`;
     }
 
-    function buildEpisodePageText(episode, fetchedPlayerUrl = '') {
+    function buildEpisodePageText(episode, episodeUrl = '', fetchedPlayerUrl = '') {
         const tracklistResult = { text: '<list>\n\n</list>', status: 'none' };
         const categories = [episode.date ? episode.date.slice(0, 4) : '', episode.artist, config.showCategory, 'Techno', `Tracklist: ${tracklistResult.status}`]
             .filter(Boolean)
@@ -236,11 +236,13 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         const imageReference = buildImageReference(episode);
         const imageText = imageReference ? `${imageReference}\n\n` : '';
 
-        return `${imageText}== File details ==\n\n${buildFileDetailsText(episode)}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
+        const notesText = episodeUrl ? `\n\n== Notes ==\n\n${episodeUrl}` : '';
+
+        return `${imageText}== File details ==\n\n${buildFileDetailsText(episode)}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}${notesText}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
     }
 
     function setCreateLinkHref(link, episode, episodeUrl, fetchedPlayerUrl = '') {
-        link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, fetchedPlayerUrl));
+        link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, episodeUrl, fetchedPlayerUrl));
     }
 
     function bindCreateLinkRefreshOnClick(link, episode, episodeUrl) {


### PR DESCRIPTION
### Motivation
- Prevent fetched embed/player URLs from overriding curated mirrors in `player_episodes.js` so the generated `{{Player}}` block uses the expected set of mirrors for each IA MIX episode.
- Include the source episode page URL in generated MixesDB page text so creators have an immediate reference to the original post.
- Bump the IA MIX userscript version and dependency cache parameter to ensure the updated behavior is delivered to users.

### Description
- Change `getPlayerUrlsForEpisode` to prefer configured URLs from `player_episodes.js` and use the fetched embed URL only as a fallback when no configured URLs exist.
- Update `buildEpisodePageText` signature to accept `episodeUrl` and insert a `== Notes ==` section containing the episode page URL before the `== Tracklist ==` section when available.
- Pass `episodeUrl` through `setCreateLinkHref` so the Notes section receives the correct source URL.
- Bump `// @version` and the `funcs.js` `v-` cache query parameter to `2026.07.20.9`.

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js` and it succeeded.
- Ran `node --check private/Episodes_Importer/IA_MIX/player_episodes.js` and it succeeded.
- Ran `git diff --check` and it succeeded (no whitespace errors).
- Executed a Node validation snippet that confirms IA MIX `402` resolves to the three configured player URLs and excludes the fetched SoundCloud embed URL, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e6b17a0b88320806a370f5c53b8d1)