### PR TITLE
IA_MIX: load external player_episodes, prefer configured players, and include episode URL in page text

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.8
+// @version      2026.07.20.10
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.8
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.10
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.10
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -34,7 +35,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     const sourceHost = 'inverted-audio.com';
-    let playerEpisodes = {};
+    let playerEpisodes = window.MixesDBIaMixPlayerEpisodes || {};
     const mixesdbHost = 'www.mixesdb.com';
     const config = {
         categoryTitle: 'Category:IA_MIX',
@@ -165,12 +166,12 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
 
     function getPlayerUrlsForEpisode(episode, fetchedPlayerUrl = '') {
         const episodeKey = String(episode.episodeNumber);
-        const playerUrls = [
+        const configuredPlayerUrls = [
             normalizePlayerEpisodeEntry(playerEpisodes.applePodcasts?.[episodeKey]),
             normalizePlayerEpisodeEntry(playerEpisodes.mixcloud?.[episodeKey]),
             normalizePlayerEpisodeEntry(playerEpisodes.soundcloud?.[episodeKey]),
-            fetchedPlayerUrl,
         ].filter(Boolean);
+        const playerUrls = configuredPlayerUrls.length ? configuredPlayerUrls : [fetchedPlayerUrl].filter(Boolean);
 
         return Array.from(new Set(playerUrls));
     }
@@ -227,7 +228,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         return `[[File:${buildMixesdbTitle(episode)}.jpg|right|360px]]`;
     }
 
-    function buildEpisodePageText(episode, fetchedPlayerUrl = '') {
+    function buildEpisodePageText(episode, episodeUrl = '', fetchedPlayerUrl = '') {
         const tracklistResult = { text: '<list>\n\n</list>', status: 'none' };
         const categories = [episode.date ? episode.date.slice(0, 4) : '', episode.artist, config.showCategory, 'Techno', `Tracklist: ${tracklistResult.status}`]
             .filter(Boolean)
@@ -236,11 +237,13 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         const imageReference = buildImageReference(episode);
         const imageText = imageReference ? `${imageReference}\n\n` : '';
 
-        return `${imageText}== File details ==\n\n${buildFileDetailsText(episode)}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
+        const notesText = episodeUrl ? `\n\n== Notes ==\n\n${episodeUrl}` : '';
+
+        return `${imageText}== File details ==\n\n${buildFileDetailsText(episode)}${buildPlayerText(getPlayerUrlsForEpisode(episode, fetchedPlayerUrl))}${notesText}\n\n== Tracklist ==\n\n${tracklistResult.text}\n\n${categories}`;
     }
 
     function setCreateLinkHref(link, episode, episodeUrl, fetchedPlayerUrl = '') {
-        link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, fetchedPlayerUrl));
+        link.href = importer.buildMixesdbUrl(buildMixesdbTitle(episode), episodeUrl, buildEpisodePageText(episode, episodeUrl, fetchedPlayerUrl));
     }
 
     function bindCreateLinkRefreshOnClick(link, episode, episodeUrl) {
@@ -509,6 +512,8 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
     }
 
     async function loadPlayerEpisodes() {
+        if (Object.keys(playerEpisodes).length) return;
+
         const url = 'https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?fresh=' + Date.now();
         const response = await fetch(url, { cache: 'no-store' });
         if (!response.ok) throw new Error(`player_episodes.js responded with ${response.status}`);


### PR DESCRIPTION
### Motivation
- Load canonical player metadata from a centralized `player_episodes.js` source so configured player URLs and durations are available. 
- Prefer configured player entries over an automatically fetched player URL when building the Player section. 
- Include the episode source URL in the generated MixesDB page text so the original episode page is recorded.

### Description
- Bumped userscript version and updated `@require` references to the new `funcs.js` and added `player_episodes.js` via `@require` with matching cache-bust versions. 
- Initialize `playerEpisodes` from `window.MixesDBIaMixPlayerEpisodes` and add `loadPlayerEpisodes` early-return when data is already loaded to avoid refetching. 
- Change `getPlayerUrlsForEpisode` to prefer configured player entries (`applePodcasts`, `mixcloud`, `soundcloud`) and only fall back to the fetched player URL. 
- Add an `episodeUrl` parameter to `buildEpisodePageText` and include a `Notes` section containing the original episode URL. 
- Update `setCreateLinkHref` to pass the `episodeUrl` through to the page text builder. 

### Testing
- No automated tests were run for this userscript change because there are no CI/unit tests for the userscript in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e6b17a0b88320806a370f5c53b8d1)