### PR TITLE
Update IA MIX player ordering and duration format

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.9
+// @version      2026.07.20.10
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,7 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.9
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.10
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.20.10
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -171,8 +172,13 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             normalizePlayerEpisodeEntry(playerEpisodes.soundcloud?.[episodeKey]),
         ].filter(Boolean);
         const playerUrls = configuredPlayerUrls.length ? configuredPlayerUrls : [fetchedPlayerUrl].filter(Boolean);
+        const uniquePlayerUrls = Array.from(new Set(playerUrls));
 
-        return Array.from(new Set(playerUrls));
+        if (typeof sortPlayerUrlsByPreferredOrder === 'function') {
+            return sortPlayerUrlsByPreferredOrder(uniquePlayerUrls);
+        }
+
+        return uniquePlayerUrls;
     }
 
     function getEpisodeDurationSeconds(episode) {
@@ -195,11 +201,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         const minutes = Math.floor((totalSeconds % 3600) / 60);
         const remainingSeconds = totalSeconds % 60;
 
-        if (hours > 0) {
-            return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
-        }
-
-        return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+        return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
     }
 
     function buildFileDetailsText(episode) {


### PR DESCRIPTION
### Motivation
- Ensure IA MIX episodes use the shared `Player_URLs` ordering rules (respecting `preferredPlayerSiteOrder`) so player URLs appear in the desired site order. 
- Unify duration formatting so even sub-hour durations are rendered as `H:MM:SS` (e.g. `0:51:22`) to match the IA MIX presentation requirement. 

### Description
- Bump the IA MIX userscript metadata version to `2026.07.20.10` and update the cache-busted dependency query for `funcs.js` to `v-2026.07.20.10`. 
- Add a `@require` for `private/Player_URLs/funcs.js?v-2026.07.20.10` so shared player helpers are available. 
- Route IA MIX player URL selection through the shared sorter by returning `sortPlayerUrlsByPreferredOrder(uniquePlayerUrls)` when available. 
- Change `formatDuration` to always return the `H:MM:SS` form (including a leading `0:` for durations under one hour). 

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js` and it completed successfully. 
- Ran `git diff --check` and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e738335648320806683c45f243280)