### PR TITLE
IA MIX: bump version, enforce H:MM:SS durations and preferred player ordering

### DIFF
--- a/private/Episodes_Importer/IA_MIX/script.user.js
+++ b/private/Episodes_Importer/IA_MIX/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IA MIX (private)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.07.20.10
+// @version      2026.07.20.11
 // @description  Add MixesDB creation links to Inverted Audio IA MIX episodes.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,8 +10,9 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-IA_MIX_1
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.10
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.10
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/funcs.js?v-2026.07.20.11
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Player_URLs/funcs.js?v-2026.07.20.11
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/private/Episodes_Importer/IA_MIX/player_episodes.js?v-2026.07.20.11
 // @include      https://inverted-audio.com/mix*
 // @include      https://www.mixesdb.com/w/index.php*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=inverted-audio.com
@@ -172,8 +173,11 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
             normalizePlayerEpisodeEntry(playerEpisodes.soundcloud?.[episodeKey]),
         ].filter(Boolean);
         const playerUrls = configuredPlayerUrls.length ? configuredPlayerUrls : [fetchedPlayerUrl].filter(Boolean);
+        const uniquePlayerUrls = Array.from(new Set(playerUrls));
 
-        return Array.from(new Set(playerUrls));
+        return typeof sortPlayerUrlsByPreferredOrder === 'function'
+            ? sortPlayerUrlsByPreferredOrder(uniquePlayerUrls)
+            : uniquePlayerUrls;
     }
 
     function getEpisodeDurationSeconds(episode) {
@@ -196,11 +200,7 @@ loadRawCss( githubPath_raw + "includes/global.css?v-" + scriptName + "_" + cache
         const minutes = Math.floor((totalSeconds % 3600) / 60);
         const remainingSeconds = totalSeconds % 60;
 
-        if (hours > 0) {
-            return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
-        }
-
-        return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+        return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
     }
 
     function buildFileDetailsText(episode) {


### PR DESCRIPTION
### Motivation
- Ensure IA MIX userscript is up-to-date with today's version and cache-busted helper URLs. 
- Use the shared Player_URLs helpers to present player mirrors in the preferred site order. 
- Always format durations as H:MM:SS so sub-hour durations display as `0:MM:SS` per IA MIX formatting rules.

### Description
- Bumped the userscript `@version` and updated `@require` URLs to `v-2026.07.20.11` in `private/Episodes_Importer/IA_MIX/script.user.js`.
- Added a `@require` for `private/Player_URLs/funcs.js?v-2026.07.20.11` so IA MIX can use `preferredPlayerSiteOrder` helpers.
- Updated `getPlayerUrlsForEpisode` to deduplicate player URLs and call `sortPlayerUrlsByPreferredOrder` when available, falling back to the unique list otherwise.
- Changed `formatDuration` to always return `H:MM:SS` (including `0:MM:SS` for durations under an hour).

### Testing
- Ran `node --check private/Episodes_Importer/IA_MIX/script.user.js`, which succeeded.
- Ran `git diff --check`, which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e745abf3c8320980bee8b21af4ffc)