### PR TITLE
Restrict TrackId pagination clicks to audiostreams tracklists

### DIFF
--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.05.1
+// @version      2026.08.05.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -1365,6 +1365,12 @@ function getTidGridRowsForTable( grid, gridMain ) {
     return paginatedRows && paginatedRows.length ? $( paginatedRows ) : $( ".MuiDataGrid-row", grid );
 }
 
+function isTidAudiostreamTracklistGrid( gridMain ) {
+    return urlPath_noParams( 1 ) == "audiostreams"
+        && urlPath_noParams( 2 )
+        && $( ".MuiDataGrid-virtualScrollerRenderZone", gridMain ).length;
+}
+
 function waitForTidPaginationChange( gridMain, previousText, callback ) {
     var attempts = 0,
         timer = setInterval(function() {
@@ -1384,6 +1390,11 @@ function waitForTidPaginationChange( gridMain, previousText, callback ) {
 }
 
 function loadTidPaginatedGridRows( gridMain, callback ) {
+    if( !isTidAudiostreamTracklistGrid( gridMain ) ) {
+        callback( gridMain );
+        return;
+    }
+
     var gridRoot = gridMain.closest( ".MuiDataGrid-root" ),
         paginationTextNode = $(".MuiTablePagination-displayedRows", gridRoot),
         pagination = parseTidPaginationText( paginationTextNode.text() ),


### PR DESCRIPTION
### Motivation

- Prevent the paginated-grid click automation from triggering on unrelated pages by restricting it to TrackId audiostream tracklists that actually use the data-grid render zone.

### Description

- Add `isTidAudiostreamTracklistGrid(gridMain)` which returns true only when `urlPath_noParams(1) == "audiostreams"`, a second path segment exists, and a `.MuiDataGrid-virtualScrollerRenderZone` is present in `gridMain`.
- Short-circuit `loadTidPaginatedGridRows` to immediately call back when `isTidAudiostreamTracklistGrid` is false so pagination clicks are not triggered on other pages.
- Bump the userscript `@version` header to `2026.08.05.2`.

### Testing

- Ran `node --check TrackId.net/script.user.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7309561fd4832090d7a3bb09fce694)