### PR TITLE
Prevent persisted filters from hiding playlists on SoundCloud /sets tab

### DIFF
--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.06.1
+// @version      2026.08.06.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -110,7 +110,7 @@ const getSlugFromSoundItem = (soundItem) => {
 };
 
 const hideIfXed = (soundItem) => {
-    if (!isHideXedEnabled()) return;
+    if (isSetsTab || !isHideXedEnabled()) return;
 
     const slug = getSlugFromSoundItem(soundItem);
     if (slug && isXed(slug)) {
@@ -156,6 +156,12 @@ const isSetPage = ( urlPath_noParams(2) == "sets" ) ? true : false,
       isSetsTab = isSetPage && !urlPath_noParams(3);
 logVar( 'isSetPage (= "'+urlPath_noParams(2)+'")', isSetPage );
 logVar( "isSetsTab", isSetsTab );
+
+// The sets tab only shows an informational placeholder instead of filter
+// controls, so no persisted hide option may remove its playlist entries.
+if( isSetsTab ) {
+    getHidePl = getHideReposts = getHideFav = getHideUsed = getHideXed = "false";
+}
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * *


### PR DESCRIPTION
### Motivation

- The sets tab on user profile pages shows an informational placeholder for filters but persisted hide options were still removing playlist entries, so users saw their playlists disappear despite the UI being disabled.

### Description

- Bumped the userscript version to `2026.08.06.2`.
- When `isSetsTab` is true, force `getHidePl`, `getHideReposts`, `getHideFav`, `getHideUsed`, and `getHideXed` to `"false"` so persisted hide options are not applied on the sets tab.
- Guarded `hideIfXed` so it returns immediately on the sets tab and therefore will not remove X’ed items there.

### Testing

- Ran `node --check SoundCloud/script.user.js` and it passed.
- Ran `git diff --check` and it reported no problems.
- Ran `python /opt/codex/mcp/make_pr.py --help` and it failed due to a missing `mcp` Python package (tooling issue unrelated to the userscript itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a743f69e2a4832096386e99b9b26232)