### PR TITLE
Support new SoundCloud Material UI Track header: toolkit, artwork and controls

### DIFF
--- a/SoundCloud/script.css
+++ b/SoundCloud/script.css
@@ -103,6 +103,49 @@ a.sc_button-mdb:active {
     line-height: 1.4em;
 }
 
+section[aria-label="Track header"] + .mdb-track-header-extension {
+    box-sizing: border-box;
+    width: 100%;
+    margin-top: 10px;
+}
+
+.mdb-track-header-extension .mdb-track-actions {
+    display: flex;
+    gap: 7px;
+    align-items: center;
+    min-height: 26px;
+}
+
+.mdb-track-header-extension .mdb-track-actions:empty {
+    display: none;
+}
+
+.mdb-track-header-extension .mdb-track-toolkit,
+.mdb-track-header-extension .mdb-track-toolkit > * {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: none;
+}
+
+section[aria-label="Track header"] #mdb-artwork-wrapper {
+    position: relative;
+}
+
+section[aria-label="Track header"] #mdb-artwork-input-wrapper {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
+}
+
+section[aria-label="Track header"] .mdb-artwork-img,
+section[aria-label="Track header"] .mdb-artwork-img > img {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
 #mdb-artwork-input,
 #mdb-artwork-info {
     height: 20px;

--- a/SoundCloud/script.funcs.js
+++ b/SoundCloud/script.funcs.js
@@ -8,7 +8,7 @@ log( "script.funcs.js loaded" );
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 // append_artwork()
-function append_artwork( artwork_url ) {
+function append_artwork( artwork_url, artworkImg ) {
     logFunc( "append_artwork" );
 
     // also change for upload form [?]
@@ -20,7 +20,19 @@ function append_artwork( artwork_url ) {
     logVar( "origUrl", origUrl );
 
     if( $("#mdb-artwork-wrapper").length === 0 ) {
-        if( $(".listenArtworkWrapper").length ) {
+        if( artworkImg && artworkImg.length ) {
+            var currentImg = artworkImg.first(),
+                currentWrapper = currentImg.parent();
+
+            currentWrapper.attr("id", "mdb-artwork-wrapper");
+            currentImg.wrap('<a class="mdb-artwork-img" href="'+origUrl+'" target="_blank"></a>');
+            currentWrapper.append( createArtworkInfoWrapper( origUrl, {
+                wrapperId: "mdb-artwork-input-wrapper",
+                inputId: "mdb-artwork-input",
+                inputClass: "selectOnClick",
+                infoId: "mdb-artwork-info"
+            }) );
+        } else if( $(".listenArtworkWrapper").length ) {
             $(".listenArtworkWrapper").replaceWith('<div id="mdb-artwork-wrapper"></div>');
             var imgWrapper = $("#mdb-artwork-wrapper");
 

--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.06.2
+// @version      2026.08.06.3
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -11,7 +11,7 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_35
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-SoundCloud_52
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_24
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_25
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v_2
 // @include      http*soundcloud.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=soundcloud.com
@@ -35,7 +35,7 @@ redirectOnUrlChange( 60 );
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 44,
+var cacheVersion = 45,
     scriptName = "SoundCloud";
 
 const xedItemsStorageKey = 'mdb-soundcloud-xed-items',
@@ -196,6 +196,14 @@ waitForKeyElements(".listenInfo .image span.sc-artwork[style*='background-image'
         if( typeof artwork_url !== "undefined" && artwork_url !== styleAttr ) {
             append_artwork( artwork_url );
         }
+    }
+});
+
+// Artwork in the current Material UI track header.
+waitForKeyElements('section[aria-label="Track header"] img.MuiCardMedia-img:not(.mdb-processed-artwork)', function( jNode ) {
+    if( urlPath(2) && urlPath(2) != "sets" ) {
+        jNode.addClass("mdb-processed-artwork");
+        append_artwork( jNode.attr("src"), jNode );
     }
 });
 
@@ -521,7 +529,7 @@ waitForKeyElements(".soundActions", function( jNode ) {
 // run all this only once
 var RUN_sc_button_group = true;
 
-waitForKeyElements(".l-listen-wrapper .soundActions .sc-button-group, .listen-content .soundActions .sc-button-group", function( jNode ) {
+waitForKeyElements(".l-listen-wrapper .soundActions .sc-button-group, .listen-content .soundActions .sc-button-group, .mdb-track-actions", function( jNode ) {
     if( RUN_sc_button_group ) {
         RUN_sc_button_group = false;
 
@@ -617,7 +625,7 @@ waitForKeyElements(".l-listen-wrapper .soundActions .sc-button-group, .listen-co
                                             durToggleWrapper = getFileDetails_forToggle( dur_sec, bytes ),
                                             dur = convertHMS( dur_sec );
 
-                                        soundActions.after('<button id="mdb-fileInfo" class="'+soundActionFakeButtonClass+' mdb-toggle" data-toggleid="mdb-fileDetails" title="Click to copy file details" class="pointer">'+dur+'</button>');
+                                        soundActions.append('<button id="mdb-fileInfo" class="'+soundActionFakeButtonClass+' mdb-toggle" data-toggleid="mdb-fileDetails" title="Click to copy file details">'+dur+'</button>');
 
                                         $("#mdb-toggle-target").append( durToggleWrapper );
                                     }
@@ -690,6 +698,32 @@ waitForKeyElements(".soundActions a.mdb-tidSubmit.sc_button-mdb:not(.moved)", fu
 waitForKeyElements(".l-listen-hero", function( jNode ) {
     var trackHeader = '<div id="mdb-trackHeader"></div>';
     jNode.before( trackHeader );
+});
+
+/*
+ * The current track page is a single Material UI "Track header" box. Add one
+ * full-width extension below it for the API/file controls and toolkit instead
+ * of depending on the removed legacy listenDetails columns.
+ */
+waitForKeyElements('section[aria-label="Track header"]:not(.mdb-processed-track-header)', function( jNode ) {
+    if( !urlPath(2) || urlPath(2) == "sets" ) return;
+
+    jNode.addClass("mdb-processed-track-header");
+    if( $(".mdb-track-header-extension").length ) return;
+
+    var extension = $('<div class="mdb-track-header-extension">' +
+        '<div id="mdb-trackHeader"></div>' +
+        '<div class="mdb-track-actions"></div>' +
+        '<div id="mdb-toggle-target"></div>' +
+        '<div class="mdb-track-toolkit"></div>' +
+    '</div>');
+
+    jNode.after( extension );
+
+    var titleText = $('section[aria-label="Track header"] h1').first().text(),
+        playerUrl = location.protocol + '//' + location.host + location.pathname;
+
+    getToolkit( playerUrl, "playerUrl", "detail page", extension.find(".mdb-track-toolkit"), "append", titleText, "", 1, playerUrl );
 });
 
 


### PR DESCRIPTION
### Motivation

- SoundCloud changed to a single Material UI "Track header" box which broke the userscript's API/file controls, toolkit placement and in-place artwork enrichment. 
- Restore the previous MixesDB userscript features (artwork original link, file/API toggles and toolkit) by adapting to the new DOM structure.

### Description

- Add a full-width extension below the Material UI `section[aria-label="Track header"]` (`.mdb-track-header-extension`) and render the MixesDB toolkit into it via `getToolkit` so API/file controls appear at full wrapper width. 
- Reintroduce in-place artwork enrichment for the new `MuiCardMedia-img` artwork and change `append_artwork` to accept an optional `artworkImg` parameter so the script can wrap the existing image and inject the original-artwork link and metadata controls. 
- Update action-button handling to include the new action container by adding `.mdb-track-actions` to the selector list and change file-info insertion to use `append` so the added controls appear correctly in the new layout. 
- Add CSS rules to style the new extension, action row and artwork overlay within the Material UI header, and bump the userscript's `@version`, `cacheVersion`, and the required `script.funcs.js` `v` token. 
- Files changed: `SoundCloud/script.user.js`, `SoundCloud/script.funcs.js`, `SoundCloud/script.css`.

### Testing

- Run `git diff --check` and it reported no whitespace/patch issues (success). 
- Run `node --check SoundCloud/script.user.js` and `node --check SoundCloud/script.funcs.js` (syntax checks both succeeded). 
- Verified repository state via `git status --short` and `git log -1 --oneline` (commit created: "Fix SoundCloud track page integrations").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74418b2800832095d571f767705f18)