### PR TITLE
Fix SoundCloud Material track header detection

### DIFF
--- a/SoundCloud/script.css
+++ b/SoundCloud/script.css
@@ -103,7 +103,8 @@ a.sc_button-mdb:active {
     line-height: 1.4em;
 }
 
-section[aria-label="Track header"] + .mdb-track-header-extension {
+.MuiCard-root + .mdb-track-header-extension,
+[aria-label="Track header"] + .mdb-track-header-extension {
     box-sizing: border-box;
     width: 100%;
     margin-top: 10px;
@@ -127,11 +128,13 @@ section[aria-label="Track header"] + .mdb-track-header-extension {
     max-width: none;
 }
 
-section[aria-label="Track header"] #mdb-artwork-wrapper {
+.MuiCard-root #mdb-artwork-wrapper,
+[aria-label="Track header"] #mdb-artwork-wrapper {
     position: relative;
 }
 
-section[aria-label="Track header"] #mdb-artwork-input-wrapper {
+.MuiCard-root #mdb-artwork-input-wrapper,
+[aria-label="Track header"] #mdb-artwork-input-wrapper {
     position: absolute;
     right: 0;
     bottom: 0;
@@ -139,8 +142,10 @@ section[aria-label="Track header"] #mdb-artwork-input-wrapper {
     z-index: 2;
 }
 
-section[aria-label="Track header"] .mdb-artwork-img,
-section[aria-label="Track header"] .mdb-artwork-img > img {
+.MuiCard-root .mdb-artwork-img,
+.MuiCard-root .mdb-artwork-img > img,
+[aria-label="Track header"] .mdb-artwork-img,
+[aria-label="Track header"] .mdb-artwork-img > img {
     display: block;
     width: 100%;
     height: 100%;

--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.06.3
+// @version      2026.08.06.4
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -35,7 +35,7 @@ redirectOnUrlChange( 60 );
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-var cacheVersion = 45,
+var cacheVersion = 46,
     scriptName = "SoundCloud";
 
 const xedItemsStorageKey = 'mdb-soundcloud-xed-items',
@@ -199,8 +199,10 @@ waitForKeyElements(".listenInfo .image span.sc-artwork[style*='background-image'
     }
 });
 
-// Artwork in the current Material UI track header.
-waitForKeyElements('section[aria-label="Track header"] img.MuiCardMedia-img:not(.mdb-processed-artwork)', function( jNode ) {
+// Artwork in the current Material UI track header. SoundCloud currently uses
+// a MuiCard without the former aria-label, so do not require a specific tag or
+// accessible label here.
+waitForKeyElements('.MuiCard-root img.MuiCardMedia-img:not(.mdb-processed-artwork), [aria-label="Track header"] img.MuiCardMedia-img:not(.mdb-processed-artwork)', function( jNode ) {
     if( urlPath(2) && urlPath(2) != "sets" ) {
         jNode.addClass("mdb-processed-artwork");
         append_artwork( jNode.attr("src"), jNode );
@@ -705,11 +707,14 @@ waitForKeyElements(".l-listen-hero", function( jNode ) {
  * full-width extension below it for the API/file controls and toolkit instead
  * of depending on the removed legacy listenDetails columns.
  */
-waitForKeyElements('section[aria-label="Track header"]:not(.mdb-processed-track-header)', function( jNode ) {
+waitForKeyElements('.MuiCard-root h1:not(.mdb-processed-track-heading), [aria-label="Track header"] h1:not(.mdb-processed-track-heading)', function( jNode ) {
     if( !urlPath(2) || urlPath(2) == "sets" ) return;
 
-    jNode.addClass("mdb-processed-track-header");
+    jNode.addClass("mdb-processed-track-heading");
     if( $(".mdb-track-header-extension").length ) return;
+
+    var trackHeader = jNode.closest('.MuiCard-root, [aria-label="Track header"]');
+    if( !trackHeader.length ) return;
 
     var extension = $('<div class="mdb-track-header-extension">' +
         '<div id="mdb-trackHeader"></div>' +
@@ -718,9 +723,9 @@ waitForKeyElements('section[aria-label="Track header"]:not(.mdb-processed-track-
         '<div class="mdb-track-toolkit"></div>' +
     '</div>');
 
-    jNode.after( extension );
+    trackHeader.after( extension );
 
-    var titleText = $('section[aria-label="Track header"] h1').first().text(),
+    var titleText = jNode.text(),
         playerUrl = location.protocol + '//' + location.host + location.pathname;
 
     getToolkit( playerUrl, "playerUrl", "detail page", extension.find(".mdb-track-toolkit"), "append", titleText, "", 1, playerUrl );


### PR DESCRIPTION
### Motivation

- SoundCloud replaced the legacy `section[aria-label="Track header"]` layout with a Material UI card, which broke the userscript's track-page toolkit, artwork handling and API/file controls insertion.

### Description

- Detect track pages by the Material UI card wrapper (`.MuiCard-root`) and compatible previous `aria-label` header so the toolkit and API/file controls are correctly inserted after the track card.
- Restore artwork processing for images inside the Material card by expanding the artwork selector to include `.MuiCard-root img.MuiCardMedia-img` and keep compatibility with older `listenInfo`/`listenArtworkWrapper` cases.
- Update the track-extension insertion logic to find the nearest `.MuiCard-root` container, mark processed headings with a new class and append the `.mdb-track-header-extension` after that container.
- Update CSS selectors to target both `.MuiCard-root` and the previous `section[aria-label="Track header"]` wrapper, bump `cacheVersion` to `46`, and bump the userscript version to `2026.08.06.4`.

### Testing

- Ran `git diff --check` with no reported issues and the changes staged as expected (success).
- Ran `node --check SoundCloud/script.user.js` which reported no syntax errors (success).
- Ran `node --check SoundCloud/script.funcs.js` which reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7444321b088320ade257874d0f836c)