### PR TITLE
SC: remove duplicate cacheVersion/scriptName declaration

### DIFF
--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.09.11
+// @version      2026.08.09.12
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -29,6 +29,13 @@
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+// Single source of truth - do NOT re-declare further down. Both values are read by the CSS
+// loading in the "Constants" section below, and `var` redeclaration silently reassigns, so a
+// second block would win and make bumping this one a no-op (that is exactly what happened
+// before: the two numbers drifted apart unnoticed).
+// Must also stay ABOVE the frame handling, which returns early for frames we skip: toolkit.js
+// reads the bare global `scriptName` from a d.ready() callback that fires in *every* frame,
+// so leaving it unset there would throw a ReferenceError.
 var cacheVersion = 76,
     scriptName = "SoundCloud";
 window.scriptName = scriptName; // toolkit.js reads this global directly
@@ -42,7 +49,7 @@ logVar( "cacheVersion", cacheVersion );
  *
  * All off in the shipped script - flip one to true while working on a feature.
  * They sit on window because the code reading them lives in the @require'd script.funcs.js,
- * which cannot see this IIFE's scope (same reason as window.scriptName further down).
+ * which cannot see this IIFE's scope (same reason as window.scriptName just above).
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -179,12 +186,6 @@ if( isTopFrame ) {
  * Constants
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-var cacheVersion = 76,
-    scriptName = "SoundCloud";
-window.scriptName = scriptName; // toolkit.js reads this global directly
-logVar( "scriptName", scriptName );
-logVar( "cacheVersion", cacheVersion );
 
 const xedItemsStorageKey = 'mdb-soundcloud-xed-items',
       hideXedItemsKey = 'mdb-soundcloud-hide-xed',


### PR DESCRIPTION
`cacheVersion` / `scriptName` / `window.scriptName` were declared twice in `SoundCloud/script.user.js` — once at the top of the IIFE and again in the Constants section. Because `var` redeclaration just reassigns, the lower block always won and the upper one was dead code. The two numbers had already drifted apart (75 vs 74) before being synced to 76, so anyone bumping the upper block was making a silent no-op.

## Which block was kept, and why the upper one

Nothing between the two blocks reads either variable, so both positions yield identical CSS URLs — but they are **not** equivalent for `window.scriptName`:

- The frame handling returns early out of the IIFE for frames the script skips (widget players, upload targets).
- `includes/toolkit.js:1298` reads the bare global `scriptName` (`if (scriptName != "TrackId.net")`) from a `d.ready()` callback that fires in *every* frame, and it is not `typeof`-guarded.

Keeping only the lower block would therefore leave `window.scriptName` unset in the skipped frames and turn that read into a `ReferenceError`. The upper block runs before the early return, which is the current behaviour.

## Also in this change

- Added a comment at the surviving declaration explaining the redeclaration trap, so the next person bumping `cacheVersion` doesn't recreate it.
- Fixed a now-wrong cross-reference in the debug-settings comment: "same reason as `window.scriptName` further down" → "just above".
- Bumped `@version` to `2026.08.09.12` per the repo's YYYY.MM.DD.N convention.

## Notes for the reviewer

- No behaviour change intended. `cacheVersion` stays at 76, so no cache-busting side effects.
- Verified the file still parses (`new Function(src)` via deno). No runtime test covers this path — `SoundCloud/title_examples.js` only exercises title suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
