### PR TITLE
TID submit links: actually send the normalized keywords

### DIFF
--- a/1001_Tracklists/script.user.js
+++ b/1001_Tracklists/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         1001 Tracklists (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.07.2
+// @version      2026.08.09.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/1001_Tracklists/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-1001_Tracklists_24
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-1001_Tracklists_29
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-1001_Tracklists_25
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-1001_Tracklists_30
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v-1001_Tracklists_1
 // @include      http*1001tracklists.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=1001tracklists.com

--- a/InternetArchive/script.user.js
+++ b/InternetArchive/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Internet Archive (by MixesDB) (BETA)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.07.2
+// @version      2026.08.09.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/InternetArchive/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-InternetArchive_4
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-InternetArchive_5
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-InternetArchive_5
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-InternetArchive_6
 // @require      https://cdn.jsdelivr.net/npm/sorttable@1.0.2/sorttable.js
 // @include      http*archive.org/details/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=archive.org

--- a/Mixcloud/script.user.js
+++ b/Mixcloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Mixcloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.09.1
+// @version      2026.08.09.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Mixcloud/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Mixcloud_28
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-Mixcloud_198
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Mixcloud_29
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-Mixcloud_199
 // @include      http*mixcloud.com*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixcloud.com
 // @noframes

--- a/MixesDB_Userscripts_Helper/script.user.js
+++ b/MixesDB_Userscripts_Helper/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MixesDB Userscripts Helper (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.09.5
+// @version      2026.08.09.6
 // @description  Change the look and behaviour of the MixesDB website to enable feature usable by other MixesDB userscripts.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1293952534268084234
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/MixesDB_Userscripts_Helper/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Userscripts_Helper_15
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_8
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-MixesDB_Userscripts_Helper_16
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-MixesDB_Userscripts_Helper_9
 // @match        https://www.mixesdb.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=mixesdb.com
 // @noframes
@@ -164,16 +164,18 @@ d.ready(function(){ // needed for mw.config
                 playerUrl = playerUrl.replace( "hearthis.audio", "hearthis.at" );
             }
 
+            // raw titles - makeTidSubmitUrl() normalizes them
+
             // if mix page
             if( wgNamespaceNumber==0 && wgTitle!="Main Page" ) {
-                keywords = getKeywordsFromTitle( $("h1#firstHeading") )
+                keywords = $("h1#firstHeading").text();
             }
 
             // if Explorer/Mixes
             if( wgNamespaceNumber==4 && wgPageName=="MixesDB:Explorer/Mixes" ) {
                 var explorerResult = playerWrapper.closest(".explorerResult"),
                     explorerResult_title = $(".playerLink", explorerResult).attr("title");
-                keywords = normalizeTitleForSearch( explorerResult_title );
+                keywords = explorerResult_title;
             }
 
             if( playerTidCompatible == "true" ) {

--- a/Player_Checker/script.user.js
+++ b/Player_Checker/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Player Checker (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.07.2
+// @version      2026.08.09.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Player_Checker/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Player_Checker_10
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-Player_Checker_43
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-Player_Checker_11
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-Player_Checker_44
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v-Player_Checker_1
 // @include      http*finn-johannsen.de*
 // @include      http*groove.de/*/*/*/*podcast*

--- a/RA/script.user.js
+++ b/RA/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         RA (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.09.2
+// @version      2026.08.09.3
 // @description  Change the look and behaviour of ra.co to help contributing to MixesDB, e.g. add player checks and artwork URLs.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/RA/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-RA_6
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-RA_3
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-RA_7
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-RA_4
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v-RA_1
 // @match        *://ra.co/*
 // @match        *://*.ra.co/*

--- a/SoundCloud/script.user.js
+++ b/SoundCloud/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SoundCloud (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.09.10
+// @version      2026.08.09.11
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -9,8 +9,8 @@
 // @downloadURL  https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.user.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_41
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-SoundCloud_58
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-SoundCloud_42
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-SoundCloud_59
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/title_definitions.js?v_10
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/script.funcs.js?v_46
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/SoundCloud/api_funcs.js?v_3

--- a/TrackId.net/script.user.js
+++ b/TrackId.net/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TrackId.net (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.07.2
+// @version      2026.08.09.1
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,8 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-TrackId.net_110
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-TrackId.net_88
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-TrackId.net_111
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-TrackId.net_89
 // @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/Tracklist_Cue_Switcher/script.funcs.js?v_2
 // @include      http*trackid.net*
 // @include      http*mixesdb.com/w/*

--- a/YouTube/script.user.js
+++ b/YouTube/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         YouTube (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.09.1
+// @version      2026.08.09.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,8 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_19
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-YouTube_16
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-YouTube_20
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-YouTube_17
 // @match        *://*.youtube.com/*
 // @match        *://youtu.be/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=youtube.com

--- a/hearthis.at/script.user.js
+++ b/hearthis.at/script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         hearthis.at (by MixesDB)
 // @author       User:Martin@MixesDB (Subfader@GitHub)
-// @version      2026.08.09.1
+// @version      2026.08.09.2
 // @description  Change the look and behaviour of certain DJ culture related websites to help contributing to MixesDB, e.g. add copy-paste ready tracklists in wiki syntax.
 // @homepageURL  https://www.mixesdb.com/w/Help:MixesDB_userscripts
 // @supportURL   https://discord.com/channels/1258107262833262603/1261652394799005858
@@ -10,8 +10,8 @@
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/jquery-3.7.1.min.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/waitForKeyElements.js
 // @require      https://cdn.rawgit.com/mixesdb/userscripts/refs/heads/main/includes/youtube_funcs.js
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-hearthis.at_10
-// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-hearthis.at_23
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/global.js?v-hearthis.at_11
+// @require      https://raw.githubusercontent.com/mixesdb/userscripts/refs/heads/main/includes/toolkit.js?v-hearthis.at_24
 // @include      http*hearthis.at*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=hearthis.at
 // @noframes

--- a/includes/global.js
+++ b/includes/global.js
@@ -328,20 +328,23 @@ function urlIsTidSubmitCompatible( thisUrl ) {
 
 // makeTidSubmitUrl
 function makeTidSubmitUrl( playerUrl, keywords="" ) {
-    var keyowrds = normalizeTitleForSearch( keywords ),
+    // Single place where the TID keywords get normalized, so every submit link sends the
+    // same terms no matter which caller built it. Callers pass the raw title.
+    // normalizeTitleForSearch() returns undefined on empty input - keep that out of the URL.
+    var keywords_normalized = normalizeTitleForSearch( keywords ) || "",
         youtubeId = getYoutubeIdFromUrl( playerUrl );
 
     if( youtubeId && /(?:^|\.)youtube(?:-nocookie)?\.com$|(?:^|\.)youtu\.be$/i.test( new URL( playerUrl, "https://www.youtube.com" ).hostname ) ) {
         playerUrl = "https://www.youtube.com/watch?v=" + youtubeId;
     }
 
-    return 'https://trackid.net/submiturl?requestUrl='+encodeURIComponent( playerUrl )+'&keywords='+encodeURIComponent( keywords );
+    return 'https://trackid.net/submiturl?requestUrl='+encodeURIComponent( playerUrl )+'&keywords='+encodeURIComponent( keywords_normalized );
 }
 
 // makeTidSubmitLink
 function makeTidSubmitLink( thisUrl, keywords="", linkText_mode="text" ) {
-    var keyowrds = normalizeTitleForSearch( keywords ),
-        tidUrl = makeTidSubmitUrl( thisUrl, keywords ),
+    // keywords are normalized by makeTidSubmitUrl()
+    var tidUrl = makeTidSubmitUrl( thisUrl, keywords ),
         text = "Submit this player URL to TrackId.net",
         linkText = text;
 

--- a/includes/toolkit.js
+++ b/includes/toolkit.js
@@ -1237,8 +1237,7 @@ function toolkit_addTidLink( playerUrl, title ) {
                 // avoid undefined error
                 if( ( data.error && data.error.code == "notfound" )  ) {
                     // no result
-                    var keywords = normalizeTitleForSearch( title ),
-                        tidLink = makeTidSubmitLink( playerUrl, keywords, "text" );
+                    var tidLink = makeTidSubmitLink( playerUrl, title, "text" );
                     if( tidLink ) {
                         jNode.append( '<li class="mdb-toolkit-tidLink filled">'+tidLink+'</li>' ).show();
                     }


### PR DESCRIPTION
## What

`makeTidSubmitUrl()` and `makeTidSubmitLink()` in `includes/global.js` both opened with:

```js
var keyowrds = normalizeTitleForSearch( keywords ),
```

Note the typo. The normalized value was never read — the URL was built from the raw `keywords` parameter, so `normalizeTitleForSearch()` had **no effect on any TrackId.net submit link**.

## Why it mattered more than a dead variable

Two of the three call sites normalized the title themselves before calling; one did not. So the icon link and the text link for the *same player on the same page* sent different keywords to TrackId.net:

| Path | Call site | Keywords sent before |
|---|---|---|
| A | `toolkit.js:466` — icon link | **raw** (`titleText` arrives un-normalized) |
| B | `toolkit.js:1240` — text link | normalized (caller did it) |
| C | `MixesDB_Userscripts_Helper:198` | normalized (caller did it) |

## What changed

`makeTidSubmitUrl()` is now the single place that normalizes — matching what the sibling helper `makeMixesdbSearchUrl()` already does correctly — and callers pass the raw title.

The hand-normalization in the callers is removed so a title is normalized **exactly once**. Normalizing twice is not a no-op: `normalizeTitleForSearch()` replaces `/` *after* it has already collapsed whitespace, so a slash leaves a double space that a second pass would collapse. Removing the caller-side calls is what keeps paths B and C byte-identical to before.

Also guarded with `|| ""`: `normalizeTitleForSearch()` returns `undefined` on empty input, and `encodeURIComponent(undefined)` is the string `"undefined"`. Without the guard, every player without a title would have gotten a literal `&keywords=undefined`. This is a live case — both functions default `keywords` to `""`, `makeAvailableLinksListItem()` defaults `titleText` to `""`, and `toolkit.js:912` logs "No titleText!".

## Verification

Checked against the 40 real reported titles in `SoundCloud/title_examples.js`:

- **Paths B and C: 0 differences** across 42 cases — byte-identical URLs to before.
- **Path A: 33 of 42 changed**, which is the intended fix. E.g. `"Trommel.251 - Arno"` → `Trommel 251 Arno`, `"DSS 139 | Solma"` → `DSS 139 Solma`.
- Empty titles now produce `&keywords=` instead of `&keywords=undefined`.
- The `youtu.be` → `watch?v=` rewrite still works.
- `deno run --allow-read SoundCloud/title_examples_test.js` → **40 examples, all pass**. `normalizeTitleForSearch()` itself is unchanged, so the title suggestion is untouched.

## Reviewer notes

This is a **behaviour change** to what every icon-link submit sends to TrackId.net, not a pure cleanup.

Worth a second opinion: month-stripping is aggressive — `"House Set August 2026"` → `"House Set 2026"`, `"Adriana Lopez at RAW x Monnom Black | Mar 2026"` → `"... Monnom Black 2026"`. That already applied to paths B and C so it is not new, but it now also hits path A. If TID matches better *with* the month, that is a separate tweak to `normalizeTitleForSearch()`.

Left alone deliberately: the slash/double-space ordering quirk in `normalizeTitleForSearch()`, since that function is shared with `makeMixesdbSearchUrl()` and the SoundCloud title suggestion.

## Versions

Bumped only the 10 scripts that load `toolkit.js` (plus MUH) — the TID helpers are only called from there, so the ~13 `global.js`-only scripts see no functional change and were left alone per `CLAUDE.md`.

| Script | @version | global.js | toolkit.js |
|---|---|---|---|
| MixesDB_Userscripts_Helper | 2026.08.09.6 | _16 | _9 |
| SoundCloud | 2026.08.09.11 | _42 | _59 |
| RA | 2026.08.09.3 | _7 | _4 |
| Mixcloud | 2026.08.09.2 | _29 | _199 |
| YouTube | 2026.08.09.2 | _20 | _17 |
| hearthis.at | 2026.08.09.2 | _11 | _24 |
| TrackId.net | 2026.08.09.1 | _111 | _89 |
| 1001_Tracklists | 2026.08.09.1 | _25 | _30 |
| Player_Checker | 2026.08.09.1 | _11 | _44 |
| InternetArchive | 2026.08.09.1 | _5 | _6 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)